### PR TITLE
added links to fixtures, terraform.tfvars

### DIFF
--- a/test/fixtures/compute_instance/simple/terraform.tfvars
+++ b/test/fixtures/compute_instance/simple/terraform.tfvars
@@ -1,0 +1,1 @@
+../../shared/terraform.tfvars

--- a/test/fixtures/mig/autoscaler/terraform.tfvars
+++ b/test/fixtures/mig/autoscaler/terraform.tfvars
@@ -1,0 +1,1 @@
+../../shared/terraform.tfvars


### PR DESCRIPTION
The symbolic links were absent in the original state of repository.
Their absence caused the error  during the execution of
the integration tests (make test_integration)