### PR TITLE
added instance_group to outputs

### DIFF
--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -18,3 +18,8 @@ output "self_link" {
   description = "Self-link of managed instance group"
   value       = "${google_compute_region_instance_group_manager.mig.self_link}"
 }
+
+output "instance_group" {
+  description = "Instance-group url of managed instance group"
+  value       = "${google_compute_region_instance_group_manager.mig.instance_group}"
+}


### PR DESCRIPTION
Added instance_group to outputs. This is needed by load balancers so will be useful when using with terraform LB module with MIG as a backend.