### PR TITLE
add create_both_preemptible_and_regular to instance_template

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -39,6 +39,11 @@ suites:
       name: terraform
       command_timeout: 1800
       root_module_directory: test/fixtures/instance_template/additional_disks
+  - name: it_additional_it
+    driver:
+      name: terraform
+      command_timeout: 1800
+      root_module_directory: test/fixtures/instance_template/additional_it
   - name: instance_simple
     driver:
       name: terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- the `preemptible` option on the `instance_template` submodule. [#14]
+- the `create_both_preemptible_and_regular` option on the `instance_template` submodule. [#17]
+- `another_name` and `another_self_link` outputs on the `instance_template` submodule. [#17]
+
 ## [0.2.0] - 2019-05-30
 
 ### Added

--- a/examples/instance_template/additional_it/README.md
+++ b/examples/instance_template/additional_it/README.md
@@ -1,0 +1,28 @@
+# instance-template-additional\_it
+
+This creates instance templates for both preemptible VM and regular VM
+
+[^]: (autogen_docs_start)
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| credentials\_path | The path to the GCP credentials JSON file | string | n/a | yes |
+| labels | Labels, provided as a map | map | n/a | yes |
+| project\_id | The GCP project to use for integration tests | string | n/a | yes |
+| region | The GCP region to create and test resources in | string | n/a | yes |
+| service\_account | Service account email address and scopes | map | n/a | yes |
+| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
+| tags | Network tags, provided as a list | list | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| another\_name | Name of the another instance templates |
+| another\_self\_link | Self-link to the another instance template |
+| name | Name of the instance templates |
+| self\_link | Self-link to the instance template |
+
+[^]: (autogen_docs_end)

--- a/examples/instance_template/additional_it/main.tf
+++ b/examples/instance_template/additional_it/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/instance_template/additional_it/main.tf
+++ b/examples/instance_template/additional_it/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-output "self_link" {
-  value = "${google_compute_instance_template.tpl.self_link}"
+provider "google" {
+  credentials = "${file(var.credentials_path)}"
+  project     = "${var.project_id}"
+  region      = "${var.region}"
+  version     = "~> 1.19"
 }
 
-output "name" {
-  value = "${google_compute_instance_template.tpl.name}"
-}
+module "instance_template" {
+  source          = "../../../modules/instance_template"
+  subnetwork      = "${var.subnetwork}"
+  service_account = "${var.service_account}"
+  name_prefix     = "additional-it"
+  tags            = "${var.tags}"
+  labels          = "${var.labels}"
 
-output "another_self_link" {
-  value = "${google_compute_instance_template.tpl2.0.self_link}"
-}
-
-output "another_name" {
-  value = "${google_compute_instance_template.tpl2.0.name}"
+  create_both_preemptible_and_regular = "true"
 }

--- a/examples/instance_template/additional_it/outputs.tf
+++ b/examples/instance_template/additional_it/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/instance_template/additional_it/outputs.tf
+++ b/examples/instance_template/additional_it/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,21 @@
  */
 
 output "self_link" {
-  value = "${google_compute_instance_template.tpl.self_link}"
+  description = "Self-link to the instance template"
+  value       = "${module.instance_template.self_link}"
 }
 
 output "name" {
-  value = "${google_compute_instance_template.tpl.name}"
+  description = "Name of the instance templates"
+  value       = "${module.instance_template.name}"
 }
 
 output "another_self_link" {
-  value = "${google_compute_instance_template.tpl2.0.self_link}"
+  description = "Self-link to the another instance template"
+  value       = "${module.instance_template.another_self_link}"
 }
 
 output "another_name" {
-  value = "${google_compute_instance_template.tpl2.0.name}"
+  description = "Name of the another instance templates"
+  value       = "${module.instance_template.another_name}"
 }

--- a/examples/instance_template/additional_it/variables.tf
+++ b/examples/instance_template/additional_it/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/instance_template/additional_it/variables.tf
+++ b/examples/instance_template/additional_it/variables.tf
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "credentials_path" {
+  description = "The path to the GCP credentials JSON file"
+}
+
+variable "project_id" {
+  description = "The GCP project to use for integration tests"
+}
+
+variable "region" {
+  description = "The GCP region to create and test resources in"
+}
+
+variable "subnetwork" {
+  description = "The name of the subnetwork create this instance in."
+  default     = ""
+}
+
+variable "service_account" {
+  type        = "map"
+  description = "Service account email address and scopes"
+}
+
+variable "tags" {
+  type        = "list"
+  description = "Network tags, provided as a list"
+}
+
+variable "labels" {
+  type        = "map"
+  description = "Labels, provided as a map"
+}

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -19,6 +19,7 @@ See the [simple](examples/instance_template/simple) for a usage example.
 | additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute\_instance\_template.html#disk\_name | list | `<list>` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | string | `"true"` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | string | `"false"` | no |
+| create\_both\_preemptible\_and\_regular | Create both preemptible and regular instance templates if it's true | string | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |
 | labels | Labels, provided as a map | map | `<map>` | no |
@@ -40,6 +41,8 @@ See the [simple](examples/instance_template/simple) for a usage example.
 
 | Name | Description |
 |------|-------------|
+| another\_name |  |
+| another\_self\_link |  |
 | name |  |
 | self\_link |  |
 

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -74,7 +74,7 @@ resource "google_compute_instance_template" "tpl" {
 }
 
 resource "google_compute_instance_template" "tpl2" {
-  count = "${var.create_both_preemptible_and_regular ? 1 : 0}"
+  count                   = "${var.create_both_preemptible_and_regular ? 1 : 0}"
   name_prefix             = "${var.name_prefix}-2-"
   machine_type            = "${var.machine_type}"
   labels                  = "${var.labels}"

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -68,6 +68,35 @@ resource "google_compute_instance_template" "tpl" {
   }
 
   scheduling {
-    preemptible = "${var.preemptible}"
+    preemptible       = "${var.preemptible}"
+    automatic_restart = "${var.preemptible ? "false" : "true"}"
+  }
+}
+
+resource "google_compute_instance_template" "tpl2" {
+  count = "${var.create_both_preemptible_and_regular ? 1 : 0}"
+  name_prefix             = "${var.name_prefix}-2-"
+  machine_type            = "${var.machine_type}"
+  labels                  = "${var.labels}"
+  metadata                = "${var.metadata}"
+  tags                    = "${var.tags}"
+  can_ip_forward          = "${var.can_ip_forward}"
+  metadata_startup_script = "${var.startup_script}"
+  disk                    = ["${local.all_disks}"]
+  service_account         = ["${var.service_account}"]
+
+  network_interface {
+    network            = "${var.network}"
+    subnetwork         = "${var.subnetwork}"
+    subnetwork_project = "${var.subnetwork_project}"
+  }
+
+  lifecycle {
+    create_before_destroy = "true"
+  }
+
+  scheduling {
+    preemptible       = "${var.preemptible ? "false" : "true"}"
+    automatic_restart = "${var.preemptible}"
   }
 }

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -46,6 +46,11 @@ variable "preemptible" {
   default     = "false"
 }
 
+variable "create_both_preemptible_and_regular" {
+  description = "Create both preemptible and regular instance templates if it's true"
+  default     = "false"
+}
+
 #######
 # disk
 #######

--- a/test/fixtures/instance_template/additional_it/main.tf
+++ b/test/fixtures/instance_template/additional_it/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/instance_template/additional_it/main.tf
+++ b/test/fixtures/instance_template/additional_it/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-output "self_link" {
-  value = "${google_compute_instance_template.tpl.self_link}"
+locals {
+  credentials_path = "${path.module}/${var.credentials_path_relative}"
 }
 
-output "name" {
-  value = "${google_compute_instance_template.tpl.name}"
-}
+module "instance_template_additional_it" {
+  source           = "../../../../examples/instance_template/additional_it"
+  credentials_path = "${local.credentials_path}"
+  project_id       = "${var.project_id}"
+  region           = "${var.region}"
+  subnetwork       = "${google_compute_subnetwork.main.name}"
+  service_account  = "${var.service_account}"
+  tags             = ["foo", "bar"]
 
-output "another_self_link" {
-  value = "${google_compute_instance_template.tpl2.0.self_link}"
-}
-
-output "another_name" {
-  value = "${google_compute_instance_template.tpl2.0.name}"
+  labels = {
+    environment = "dev"
+  }
 }

--- a/test/fixtures/instance_template/additional_it/network.tf
+++ b/test/fixtures/instance_template/additional_it/network.tf
@@ -1,0 +1,1 @@
+../../shared/network.tf

--- a/test/fixtures/instance_template/additional_it/outputs.tf
+++ b/test/fixtures/instance_template/additional_it/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/instance_template/additional_it/outputs.tf
+++ b/test/fixtures/instance_template/additional_it/outputs.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,21 @@
  */
 
 output "self_link" {
-  value = "${google_compute_instance_template.tpl.self_link}"
-}
-
-output "name" {
-  value = "${google_compute_instance_template.tpl.name}"
+  description = "Self-link to the instance template"
+  value       = "${module.instance_template_additional_it.self_link}"
 }
 
 output "another_self_link" {
-  value = "${google_compute_instance_template.tpl2.0.self_link}"
+  description = "Self-link to the another instance template"
+  value       = "${module.instance_template_additional_it.another_self_link}"
 }
 
-output "another_name" {
-  value = "${google_compute_instance_template.tpl2.0.name}"
+output "project_id" {
+  description = "The GCP project to use for integration tests"
+  value       = "${var.project_id}"
+}
+
+output "credentials_path" {
+  description = "The path to the GCP credentials JSON file"
+  value       = "${local.credentials_path}"
 }

--- a/test/fixtures/instance_template/additional_it/terraform.tfvars
+++ b/test/fixtures/instance_template/additional_it/terraform.tfvars
@@ -1,0 +1,1 @@
+../../shared/terraform.tfvars

--- a/test/fixtures/instance_template/additional_it/variables.tf
+++ b/test/fixtures/instance_template/additional_it/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2019 Google LLC
+ * Copyright 2018 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/fixtures/instance_template/additional_it/variables.tf
+++ b/test/fixtures/instance_template/additional_it/variables.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2018 Google LLC
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,18 +14,19 @@
  * limitations under the License.
  */
 
-output "self_link" {
-  value = "${google_compute_instance_template.tpl.self_link}"
+variable "project_id" {
+  description = "The GCP project to use for integration tests"
 }
 
-output "name" {
-  value = "${google_compute_instance_template.tpl.name}"
+variable "region" {
+  description = "The GCP region to create and test resources in"
 }
 
-output "another_self_link" {
-  value = "${google_compute_instance_template.tpl2.0.self_link}"
+variable "credentials_path_relative" {
+  description = "The relative path from the fixture directory to the GCP credentials file that will run Terraform tests"
 }
 
-output "another_name" {
-  value = "${google_compute_instance_template.tpl2.0.name}"
+variable "service_account" {
+  type        = "map"
+  description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }

--- a/test/integration/it_additional_it/controls/it_additional_it.rb
+++ b/test/integration/it_additional_it/controls/it_additional_it.rb
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/it_additional_it/controls/it_additional_it.rb
+++ b/test/integration/it_additional_it/controls/it_additional_it.rb
@@ -1,0 +1,90 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+project_id = attribute('project_id')
+credentials_path = attribute('credentials_path')
+
+ENV['CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE'] = File.absolute_path(
+  credentials_path,
+  File.join(__dir__, "../../../fixtures/instance_template/additional_it"))
+
+expected_templates = 2
+expected_disks = 1
+
+control "Instance Template" do
+  title "Simple configuration"
+
+  describe command("gcloud --project=#{project_id} compute instance-templates list --format=json --filter='name~^additional-it*'") do
+    its(:exit_status) { should eq 0 }
+    its(:stderr) { should eq '' }
+
+    let!(:data) do
+      if subject.exit_status == 0
+        JSON.parse(subject.stdout)
+      else
+        []
+      end
+    end
+
+    describe "kind of templates" do
+      it "should be #{expected_disks}" do
+        expect(data[0]['properties']['scheduling']['preemptible']).to be_truthy
+        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_falsey
+        expect(data[1]['properties']['scheduling']['preemptible']).to be_falsey
+        expect(data[1]['properties']['scheduling']['automaticRestart']).to be_truthy
+      end
+    end
+
+    describe "number of templates" do
+      it "should be #{expected_templates}" do
+        expect(data.length).to eq(expected_templates)
+      end
+    end
+
+    describe "number of disks" do
+      it "should be #{expected_disks}" do
+        expect(data[0]['properties']['disks'].length).to eq(expected_disks)
+        expect(data[1]['properties']['disks'].length).to eq(expected_disks)
+      end
+    end
+
+    describe "network tags" do
+      it "should include 'foo'" do
+        expect(data[0]['properties']['tags']['items']).to include("foo")
+        expect(data[1]['properties']['tags']['items']).to include("foo")
+      end
+    end
+
+    describe "network tags" do
+      it "should include 'bar'" do
+        expect(data[0]['properties']['tags']['items']).to include("bar")
+        expect(data[1]['properties']['tags']['items']).to include("bar")
+      end
+    end
+
+    describe "labels" do
+      it "should include 'environment' key" do
+        expect(data[0]['properties']['labels']).to include("environment")
+        expect(data[1]['properties']['labels']).to include("environment")
+      end
+    end
+
+    describe "label" do
+      it "'environment' should have value 'dev'" do
+        expect(data[0]['properties']['labels']['environment']).to eq("dev")
+        expect(data[1]['properties']['labels']['environment']).to eq("dev")
+      end
+    end
+  end
+end

--- a/test/integration/it_additional_it/inspec.yml
+++ b/test/integration/it_additional_it/inspec.yml
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integration/it_additional_it/inspec.yml
+++ b/test/integration/it_additional_it/inspec.yml
@@ -1,0 +1,23 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: it_additional_it
+attributes:
+  - name: project_id
+    required: true
+    type: string
+  - name: credentials_path
+    required: true
+    type: string


### PR DESCRIPTION
If the option is enabled, this module creates both a regular template
and a template with the preemptible option enabled.
Even if this option and the preemptible option are both set to true,
two types of templates are created because a regular template is created internally.

@morgante @aaron-lane Any thoughts on this?