### PR TITLE
Update preemptible argument for Terraform 0.12

### DIFF
--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -98,7 +98,6 @@ resource "google_compute_instance_template" "tpl" {
   }
 
   scheduling {
-    preemptible = "${var.preemptible}"
+    preemptible = var.preemptible
   }
 }
-

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -42,8 +42,9 @@ variable "labels" {
 }
 
 variable "preemptible" {
+  type        = bool
   description = "Allow the instance to be preempted"
-  default     = "false"
+  default     = false
 }
 
 #######
@@ -134,4 +135,3 @@ variable "service_account" {
   })
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
-


### PR DESCRIPTION
I noticed the preemptible argument was missed on the original 0.12 branch as I was reviewing the CHANGELOG for release.