### PR TITLE
Fix redeploy google_compute_region_instance_group_manager on each apply

### DIFF
--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -139,5 +139,6 @@ variable "service_account" {
     email  = string
     scopes = set(string)
   })
+  default = null
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -52,9 +52,13 @@ resource "google_compute_region_instance_group_manager" "mig" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? var.min_replicas : var.target_size
 
-  auto_healing_policies {
-    health_check      = length(local.healthchecks) > 0 ? local.healthchecks[0] : ""
-    initial_delay_sec = length(local.healthchecks) > 0 ? var.hc_initial_delay_sec : 0
+  dynamic "auto_healing_policies" {
+    for_each = local.healthchecks
+    iterator = healthcheck
+    content {
+      health_check      = healthcheck.value
+      initial_delay_sec = var.hc_initial_delay_sec
+    }
   }
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -61,11 +61,15 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? var.min_replicas : var.target_size
 
-  auto_healing_policies {
-    health_check      = length(local.healthchecks) > 0 ? local.healthchecks[0] : ""
-    initial_delay_sec = length(local.healthchecks) > 0 ? var.hc_initial_delay_sec : 0
+  dynamic "auto_healing_policies" {
+    for_each = local.healthchecks
+    iterator = healthcheck
+    content {
+      health_check      = healthcheck.value
+      initial_delay_sec = var.hc_initial_delay_sec
+    }
   }
-
+  
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy


### PR DESCRIPTION
Regarding #28 
It happened because of auto_healing_policies block. It should be optional. Create a dynamic block for that.