### PR TITLE
issue #28 - RegionInstanceGroupManager is forced to be re-created - fix.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.1.1] - 2019-10-25
+
+### Fixed
+
+- `distribution_policy_zones` ignoring [#37]
+
+## [1.1.0] - 2019-10-23
+
 ### Added
 
 - Added variable `project_id`. [#26]
@@ -45,3 +53,4 @@ project adheres to [Semantic Versioning](http://semver.org/).
 [#16]: https://github.com/terraform-google-modules/terraform-google-vm/pull/16
 [#18]: https://github.com/terraform-google-modules/terraform-google-vm/pull/18
 [#26]: https://github.com/terraform-google-modules/terraform-google-vm/pull/26
+[#37]: https://github.com/terraform-google-modules/terraform-google-vm/pull/37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- `distribution_policy_zones` ignoring [#37]
+- Fix bug with `distribution_policy_zones` forcing permadiff. [#37]
 
 ## [1.1.0] - 2019-10-23
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See also the [project_services](modules/project_services) module (optional).
 ## Notes
 
 `distribution_policy_zones` cannot be changed during use. If you have changed them yourself or 
-used to a default value, then you'll have to force recreate a mig group yourself.
+used to have a default value, then you'll have to force recreate a MIG group yourself.
 
 ## Test Configuration
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ The following APIs must be enabled on your project:
 
 See also the [project_services](modules/project_services) module (optional).
 
+## Notes
+
+`distribution_policy_zones` cannot be changed during use. If you have changed them yourself or 
+used to a default value, then you'll have to force recreate a mig group yourself.
+
 ## Test Configuration
 
 1. Create a `terraform.tfvars` file, using `terraform.tfvars.example` as an example

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -56,6 +56,7 @@ resource "google_compute_region_instance_group_manager" "mig" {
     health_check      = length(local.healthchecks) > 0 ? local.healthchecks[0] : ""
     initial_delay_sec = length(local.healthchecks) > 0 ? var.hc_initial_delay_sec : 0
   }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy
@@ -72,6 +73,7 @@ resource "google_compute_region_instance_group_manager" "mig" {
 
   lifecycle {
     create_before_destroy = "true"
+    ignore_changes = ["distribution_policy_zones"]
   }
 }
 

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -20,8 +20,8 @@ locals {
     google_compute_health_check.tcp_healthcheck.*.self_link,
   )
   distribution_policy_zones_base = {
-    default = data.google_compute_zones.available.names
-    user    = var.distribution_policy_zones
+      default = data.google_compute_zones.available.names
+      user    = var.distribution_policy_zones
   }
   distribution_policy_zones = local.distribution_policy_zones_base[length(var.distribution_policy_zones) == 0 ? "default" : "user"]
 }
@@ -143,4 +143,3 @@ resource "google_compute_health_check" "tcp_healthcheck" {
     port = var.hc_port
   }
 }
-

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -20,8 +20,8 @@ locals {
     google_compute_health_check.tcp_healthcheck.*.self_link,
   )
   distribution_policy_zones_base = {
-      default = data.google_compute_zones.available.names
-      user    = var.distribution_policy_zones
+    default = data.google_compute_zones.available.names
+    user    = var.distribution_policy_zones
   }
   distribution_policy_zones = local.distribution_policy_zones_base[length(var.distribution_policy_zones) == 0 ? "default" : "user"]
 }

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -82,6 +82,7 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
 
   lifecycle {
     create_before_destroy = "true"
+    ignore_changes = ["distribution_policy_zones"]
   }
 }
 


### PR DESCRIPTION
Fixes #28

Highlight:
```
~ distribution_policy_zones = [
          - "europe-west3-a",
          - "europe-west3-b",
          - "europe-west3-c",
        ] -> (known after apply) # forces replacement
```
ignore using **lifecycle**
