### PR TITLE
Allow setting region without updating provider

### DIFF
--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -28,6 +28,7 @@ locals {
 
 data "google_compute_zones" "available" {
   project = var.project_id
+  region  = var.region
 }
 
 resource "google_compute_region_instance_group_manager" "mig" {


### PR DESCRIPTION
Currently if we work in a specific region we'll have to specify it in our google provider.
This change allows to keep a region-agnostic provider and simply pass the region to the `data.google_compute_zones.available` resource.