### PR TITLE
Fixes #9: Randomize the name arguments of resources in modules invoked by CI

### DIFF
--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -32,6 +32,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "compute_instance" {

--- a/examples/compute_instance/simple/outputs.tf
+++ b/examples/compute_instance/simple/outputs.tf
@@ -24,3 +24,12 @@ output "available_zones" {
   value       = module.compute_instance.available_zones
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}
+
+output "instances_names" {
+  description = "List of names of compute instances"
+  value       = module.compute_instance.instances_names
+}

--- a/examples/compute_instance/simple/variables.tf
+++ b/examples/compute_instance/simple/variables.tf
@@ -42,3 +42,9 @@ variable "service_account" {
   })
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
+
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/instance_template/additional_disks/main.tf
+++ b/examples/instance_template/additional_disks/main.tf
@@ -26,7 +26,7 @@ module "instance_template" {
   project_id      = var.project_id
   subnetwork      = var.subnetwork
   service_account = var.service_account
-  name_prefix     = "additional-disks"
+  name_prefix     = var.name_prefix
 
   additional_disks = [
     {

--- a/examples/instance_template/additional_disks/outputs.tf
+++ b/examples/instance_template/additional_disks/outputs.tf
@@ -23,4 +23,3 @@ output "name" {
   description = "Name of the instance templates"
   value       = module.instance_template.name
 }
-

--- a/examples/instance_template/additional_disks/variables.tf
+++ b/examples/instance_template/additional_disks/variables.tf
@@ -40,3 +40,8 @@ variable "service_account" {
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
 
+variable "name_prefix" {
+  default     = "additional-disks"
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/instance_template/simple/main.tf
+++ b/examples/instance_template/simple/main.tf
@@ -38,7 +38,7 @@ module "instance_template" {
   project_id      = var.project_id
   subnetwork      = var.subnetwork
   service_account = var.service_account
-  name_prefix     = "simple"
+  name_prefix     = var.name_prefix
   tags            = var.tags
   labels          = var.labels
   access_config   = [local.access_config]

--- a/examples/instance_template/simple/outputs.tf
+++ b/examples/instance_template/simple/outputs.tf
@@ -23,4 +23,3 @@ output "name" {
   description = "Name of the instance templates"
   value       = module.instance_template.name
 }
-

--- a/examples/instance_template/simple/variables.tf
+++ b/examples/instance_template/simple/variables.tf
@@ -50,3 +50,8 @@ variable "labels" {
   description = "Labels, provided as a map"
 }
 
+variable "name_prefix" {
+  default     = "simple"
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/mig/autoscaler/main.tf
+++ b/examples/mig/autoscaler/main.tf
@@ -33,6 +33,7 @@ module "instance_template" {
   project_id      = var.project_id
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "mig" {

--- a/examples/mig/autoscaler/outputs.tf
+++ b/examples/mig/autoscaler/outputs.tf
@@ -24,3 +24,7 @@ output "mig_self_link" {
   value       = module.mig.self_link
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/mig/autoscaler/variables.tf
+++ b/examples/mig/autoscaler/variables.tf
@@ -47,10 +47,13 @@ variable "min_replicas" {
   description = "The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0."
 }
 
-
-
 variable "autoscaling_cpu" {
   description = "Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization"
   type        = list(map(number))
 }
 
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/mig/full/main.tf
+++ b/examples/mig/full/main.tf
@@ -30,7 +30,7 @@ provider "google-beta" {
 
 module "instance_template" {
   source          = "../../../modules/instance_template"
-  name_prefix     = "${var.hostname}-instance-template"
+  name_prefix     = var.name_prefix != null ? var.name_prefix : "${var.hostname}-instance-template"
   project_id      = var.project_id
   machine_type    = var.machine_type
   tags            = var.tags

--- a/examples/mig/full/outputs.tf
+++ b/examples/mig/full/outputs.tf
@@ -24,3 +24,7 @@ output "mig_self_link" {
   value       = module.mig.self_link
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -64,8 +64,9 @@ variable "named_ports" {
 # Instance Template
 ####################
 variable "name_prefix" {
-  description = "Name prefix for the instance template"
   default     = "default-instance-template"
+  type        = string
+  description = "Optional name prefix for resources"
 }
 
 variable "machine_type" {

--- a/examples/mig/simple/main.tf
+++ b/examples/mig/simple/main.tf
@@ -32,6 +32,7 @@ module "instance_template" {
   subnetwork         = var.subnetwork
   service_account    = var.service_account
   subnetwork_project = var.project_id
+  name_prefix        = var.name_prefix
 }
 
 module "mig" {

--- a/examples/mig/simple/outputs.tf
+++ b/examples/mig/simple/outputs.tf
@@ -19,3 +19,7 @@ output "self_link" {
   value       = module.mig.self_link
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/mig/simple/variables.tf
+++ b/examples/mig/simple/variables.tf
@@ -43,3 +43,8 @@ variable "service_account" {
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
 
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/mig_with_percent/simple/main.tf
+++ b/examples/mig_with_percent/simple/main.tf
@@ -32,6 +32,7 @@ module "preemptible_and_regular_instance_templates" {
   source          = "../../../modules/preemptible_and_regular_instance_templates"
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "mig_with_percent" {

--- a/examples/mig_with_percent/simple/outputs.tf
+++ b/examples/mig_with_percent/simple/outputs.tf
@@ -18,3 +18,8 @@ output "self_link" {
   description = "Self-link of the managed instance group"
   value       = module.mig_with_percent.self_link
 }
+
+output "preemptible_name" {
+  description = "Name of the preemptible instance templates"
+  value       = module.preemptible_and_regular_instance_templates.preemptible_name
+}

--- a/examples/mig_with_percent/simple/variables.tf
+++ b/examples/mig_with_percent/simple/variables.tf
@@ -38,3 +38,9 @@ variable "service_account" {
   })
   description = "Service account email address and scopes"
 }
+
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/preemptible_and_regular_instance_templates/simple/main.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/main.tf
@@ -26,7 +26,7 @@ module "preemptible_and_regular_instance_templates" {
   subnetwork      = var.subnetwork
   project_id      = var.project_id
   service_account = var.service_account
-  name_prefix     = "pvm-and-regular-simple"
+  name_prefix     = var.name_prefix
   tags            = var.tags
   labels          = var.labels
 }

--- a/examples/preemptible_and_regular_instance_templates/simple/variables.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/variables.tf
@@ -49,3 +49,9 @@ variable "labels" {
   type        = map(string)
   description = "Labels, provided as a map"
 }
+
+variable "name_prefix" {
+  default     = "pvm-and-regular-simple"
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/umig/full/main.tf
+++ b/examples/umig/full/main.tf
@@ -30,7 +30,7 @@ provider "google-beta" {
 
 module "instance_template" {
   source          = "../../../modules/instance_template"
-  name_prefix     = "${var.hostname}-instance-template"
+  name_prefix     = var.name_prefix != null ? var.name_prefix : "${var.hostname}-instance-template"
   machine_type    = var.machine_type
   project_id      = var.project_id
   tags            = var.tags

--- a/examples/umig/full/outputs.tf
+++ b/examples/umig/full/outputs.tf
@@ -24,3 +24,7 @@ output "umig_self_links" {
   value       = module.umig.self_links
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/umig/full/variables.tf
+++ b/examples/umig/full/variables.tf
@@ -64,8 +64,9 @@ variable "named_ports" {
 # Instance Template
 ####################
 variable "name_prefix" {
-  description = "Name prefix for the instance template"
   default     = "default-instance-template"
+  type        = string
+  description = "Optional name prefix for resources"
 }
 
 variable "machine_type" {

--- a/examples/umig/named_ports/main.tf
+++ b/examples/umig/named_ports/main.tf
@@ -32,6 +32,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "umig" {

--- a/examples/umig/named_ports/outputs.tf
+++ b/examples/umig/named_ports/outputs.tf
@@ -29,3 +29,7 @@ output "available_zones" {
   value       = module.umig.available_zones
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/umig/named_ports/variables.tf
+++ b/examples/umig/named_ports/variables.tf
@@ -51,3 +51,9 @@ variable "named_ports" {
   }))
   default = []
 }
+
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/umig/simple/main.tf
+++ b/examples/umig/simple/main.tf
@@ -32,6 +32,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "umig" {

--- a/examples/umig/simple/outputs.tf
+++ b/examples/umig/simple/outputs.tf
@@ -29,3 +29,7 @@ output "available_zones" {
   value       = module.umig.available_zones
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/umig/simple/variables.tf
+++ b/examples/umig/simple/variables.tf
@@ -43,3 +43,8 @@ variable "service_account" {
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
 
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/examples/umig/static_ips/main.tf
+++ b/examples/umig/static_ips/main.tf
@@ -32,6 +32,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   subnetwork      = var.subnetwork
   service_account = var.service_account
+  name_prefix     = var.name_prefix
 }
 
 module "umig" {

--- a/examples/umig/static_ips/outputs.tf
+++ b/examples/umig/static_ips/outputs.tf
@@ -29,3 +29,7 @@ output "available_zones" {
   value       = module.umig.available_zones
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template.name
+}

--- a/examples/umig/static_ips/variables.tf
+++ b/examples/umig/static_ips/variables.tf
@@ -48,3 +48,9 @@ variable "service_account" {
   })
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
 }
+
+variable "name_prefix" {
+  default     = null
+  type        = string
+  description = "Optional name prefix for resources"
+}

--- a/modules/compute_instance/outputs.tf
+++ b/modules/compute_instance/outputs.tf
@@ -24,3 +24,7 @@ output "available_zones" {
   value       = data.google_compute_zones.available.names
 }
 
+output "instances_names" {
+  description = "List of names of compute instances"
+  value       = google_compute_instance_from_template.compute_instance.*.name
+}

--- a/test/fixtures/compute_instance/simple/main.tf
+++ b/test/fixtures/compute_instance/simple/main.tf
@@ -26,5 +26,6 @@ module "instance_simple" {
   subnetwork       = google_compute_subnetwork.main.name
   num_instances    = 4
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 }
 

--- a/test/fixtures/compute_instance/simple/outputs.tf
+++ b/test/fixtures/compute_instance/simple/outputs.tf
@@ -29,3 +29,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_simple.instance_template_name
+}

--- a/test/fixtures/instance_template/additional_disks/main.tf
+++ b/test/fixtures/instance_template/additional_disks/main.tf
@@ -25,5 +25,6 @@ module "instance_template_additional_disks" {
   region           = var.region
   subnetwork       = google_compute_subnetwork.main.name
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 }
 

--- a/test/fixtures/instance_template/additional_disks/outputs.tf
+++ b/test/fixtures/instance_template/additional_disks/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template_additional_disks.instance_template_name
+}

--- a/test/fixtures/instance_template/simple/main.tf
+++ b/test/fixtures/instance_template/simple/main.tf
@@ -26,6 +26,7 @@ module "instance_template_simple" {
   subnetwork       = google_compute_subnetwork.main.name
   service_account  = var.service_account
   tags             = ["foo", "bar"]
+  name_prefix      = random_string.suffix.result
 
   labels = {
     environment = "dev"

--- a/test/fixtures/instance_template/simple/outputs.tf
+++ b/test/fixtures/instance_template/simple/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.instance_template_simple.instance_template_name
+}

--- a/test/fixtures/mig/autoscaler/main.tf
+++ b/test/fixtures/mig/autoscaler/main.tf
@@ -27,6 +27,7 @@ module "mig_autoscaler" {
   service_account     = var.service_account
   autoscaling_enabled = "true"
   min_replicas        = 4
+  name_prefix         = random_string.suffix.result
 
   autoscaling_cpu = [
     {

--- a/test/fixtures/mig/autoscaler/outputs.tf
+++ b/test/fixtures/mig/autoscaler/outputs.tf
@@ -29,3 +29,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.mig_autoscaler.instance_template_name
+}

--- a/test/fixtures/mig/simple/main.tf
+++ b/test/fixtures/mig/simple/main.tf
@@ -26,5 +26,6 @@ module "mig_simple" {
   subnetwork       = google_compute_subnetwork.main.name
   target_size      = 4
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 }
 

--- a/test/fixtures/mig/simple/outputs.tf
+++ b/test/fixtures/mig/simple/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.mig_simple.instance_template_name
+}

--- a/test/fixtures/mig_with_percent/simple/main.tf
+++ b/test/fixtures/mig_with_percent/simple/main.tf
@@ -25,4 +25,5 @@ module "mig_with_percent_simple" {
   region           = var.region
   subnetwork       = google_compute_subnetwork.main.name
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 }

--- a/test/fixtures/mig_with_percent/simple/outputs.tf
+++ b/test/fixtures/mig_with_percent/simple/outputs.tf
@@ -34,3 +34,7 @@ output "region" {
   value       = var.region
 }
 
+output "preemptible_name" {
+  description = "Instance template name"
+  value       = module.mig_with_percent_simple.preemptible_name
+}

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/main.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/main.tf
@@ -26,6 +26,7 @@ module "preemptible_and_regular_instance_templates" {
   subnetwork       = google_compute_subnetwork.main.name
   service_account  = var.service_account
   tags             = ["foo", "bar"]
+  name_prefix      = random_string.suffix.result
 
   labels = {
     environment = "dev"

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/outputs.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/outputs.tf
@@ -33,3 +33,8 @@ output "credentials_path" {
   description = "The path to the GCP credentials JSON file"
   value       = local.credentials_path
 }
+
+output "preemptible_name" {
+  description = "Instance template name"
+  value       = module.preemptible_and_regular_instance_templates.preemptible_name
+}

--- a/test/fixtures/umig/named_ports/main.tf
+++ b/test/fixtures/umig/named_ports/main.tf
@@ -26,6 +26,7 @@ module "umig_named_ports" {
   subnetwork       = google_compute_subnetwork.main.name
   num_instances    = 4
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 
   named_ports = [
     {

--- a/test/fixtures/umig/named_ports/outputs.tf
+++ b/test/fixtures/umig/named_ports/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.umig_named_ports.instance_template_name
+}

--- a/test/fixtures/umig/simple/main.tf
+++ b/test/fixtures/umig/simple/main.tf
@@ -26,5 +26,6 @@ module "umig_simple" {
   subnetwork       = google_compute_subnetwork.main.name
   num_instances    = 4
   service_account  = var.service_account
+  name_prefix      = random_string.suffix.result
 }
 

--- a/test/fixtures/umig/simple/outputs.tf
+++ b/test/fixtures/umig/simple/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.umig_simple.instance_template_name
+}

--- a/test/fixtures/umig/static_ips/main.tf
+++ b/test/fixtures/umig/static_ips/main.tf
@@ -24,6 +24,7 @@ module "umig_static_ips" {
   project_id       = var.project_id
   region           = "us-central1"
   subnetwork       = google_compute_subnetwork.main.name
+  name_prefix      = random_string.suffix.result
 
   static_ips = [
     "10.128.0.10",

--- a/test/fixtures/umig/static_ips/outputs.tf
+++ b/test/fixtures/umig/static_ips/outputs.tf
@@ -34,3 +34,7 @@ output "credentials_path" {
   value       = local.credentials_path
 }
 
+output "instance_template_name" {
+  description = "Instance template name"
+  value       = module.umig_static_ips.instance_template_name
+}


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-vm/issues/9

Added name_prefix to all examples and fixtures.