### PR TITLE
Removing "Warning: Quoted references are deprecated"

### DIFF
--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -73,8 +73,8 @@ resource "google_compute_region_instance_group_manager" "mig" {
   }
 
   lifecycle {
-    create_before_destroy = "true"
-    ignore_changes        = ["distribution_policy_zones"]
+    create_before_destroy = true
+    ignore_changes        = [distribution_policy_zones]
   }
 }
 


### PR DESCRIPTION
Terraform 12 does not require Quotes on some variables throwing "Warning: Quoted references are deprecated"