### PR TITLE
Derive Project id for instance from instance template

### DIFF
--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -11,7 +11,7 @@ This is a simple, minimal example of how to use the compute_instance module
 | project\_id | The GCP project to use for integration tests | string | n/a | yes |
 | region | The GCP region to create and test resources in | string | `"us-central1"` | no |
 | service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+| subnetwork | The subnetwork selflink to host the compute instances in | string | n/a | yes |
 
 ## Outputs
 

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -16,22 +16,23 @@
 
 provider "google" {
 
-  project = var.project_id
   version = "~> 2.7.0"
 }
 
 module "instance_template" {
   source          = "../../../modules/instance_template"
   region          = var.region
+  project_id      = var.project_id
   subnetwork      = var.subnetwork
   service_account = var.service_account
 }
 
 module "compute_instance" {
-  source            = "../../../modules/compute_instance"
-  region            = var.region
-  subnetwork        = var.subnetwork
-  num_instances     = var.num_instances
-  hostname          = "instance-simple"
-  instance_template = module.instance_template.self_link
+  source             = "../../../modules/compute_instance"
+  region             = var.region
+  subnetwork         = var.subnetwork
+  subnetwork_project = var.project_id
+  num_instances      = var.num_instances
+  hostname           = "instance-simple"
+  instance_template  = module.instance_template.self_link
 }

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -28,11 +28,10 @@ module "instance_template" {
 }
 
 module "compute_instance" {
-  source             = "../../../modules/compute_instance"
-  region             = var.region
-  subnetwork         = var.subnetwork
-  subnetwork_project = var.project_id
-  num_instances      = var.num_instances
-  hostname           = "instance-simple"
-  instance_template  = module.instance_template.self_link
+  source            = "../../../modules/compute_instance"
+  region            = var.region
+  subnetwork        = var.subnetwork
+  num_instances     = var.num_instances
+  hostname          = "instance-simple"
+  instance_template = module.instance_template.self_link
 }

--- a/examples/compute_instance/simple/variables.tf
+++ b/examples/compute_instance/simple/variables.tf
@@ -28,7 +28,7 @@ variable "region" {
 }
 
 variable "subnetwork" {
-  description = "The subnetwork to host the compute instances in"
+  description = "The subnetwork selflink to host the compute instances in"
 }
 
 variable "num_instances" {

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -22,6 +22,7 @@ locals {
   # at the end of the list to work around "list does not have any elements so cannot
   # determine type" error when var.static_ips is empty
   static_ips = concat(var.static_ips, ["NOT_AN_IP"])
+  project_id = length(regexall("/projects/([^/]*)", var.instance_template)) > 0 ? flatten(regexall("/projects/([^/]*)", var.instance_template))[0] : null
 }
 
 ###############
@@ -29,7 +30,8 @@ locals {
 ###############
 
 data "google_compute_zones" "available" {
-  region = var.region
+  project = local.project_id
+  region  = var.region
 }
 
 #############
@@ -40,6 +42,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
   provider = google
   count    = local.num_instances
   name     = "${local.hostname}-${format("%03d", count.index + 1)}"
+  project  = local.project_id
   zone     = data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)]
 
   network_interface {

--- a/test/fixtures/compute_instance/simple/main.tf
+++ b/test/fixtures/compute_instance/simple/main.tf
@@ -19,7 +19,7 @@ module "instance_simple" {
   source          = "../../../../examples/compute_instance/simple"
   project_id      = var.project_id
   region          = "us-central1"
-  subnetwork      = google_compute_subnetwork.main.name
+  subnetwork      = google_compute_subnetwork.main.self_link
   num_instances   = 4
   service_account = var.service_account
 }


### PR DESCRIPTION
fixes #60 
- Instance template self link is of the form `https://www.googleapis.com/compute/beta/projects/project-name/../../... `Use regex to extract _{project-name}_; if not found fall back to provider level project id