### PR TITLE
Add additional variables to ensure scratch disks for templates

### DIFF
--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -95,10 +95,17 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
-    auto_delete  = bool
     boot         = bool
+    auto_delete  = bool
+    device_name  = string
+    disk_name    = string
     disk_size_gb = number
     disk_type    = string
+    interface    = string
+    mode         = string
+    source       = string
+    source_image = string
+    type         = string
   }))
   default = []
 }


### PR DESCRIPTION
Instance templates do not in their current form allow creation of scratch disks. The missing parameters mean that you end up defaulting to incompatible flags when you try to setup NVME, etc... This is an attempt to add in the missing parameters. With it I can setup an instance template with a scratch disk.