### PR TITLE
Allow the use of Google provider v3.x

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -31,8 +31,10 @@ locals {
 data "google_compute_zones" "available" {
   {% if mig %}
   project = var.project_id
-  {% endif %}
   region  = var.region
+  {% else %}
+  region = var.region
+  {% endif %}
 }
 
 resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
@@ -46,7 +48,7 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
     instance_template = var.instance_template
   }
   {% else %}
-    version {
+  version {
     name              = "${var.hostname}-mig-version-0"
     instance_template = var.instance_template_initial_version
   }

--- a/autogen/versions.tf
+++ b/autogen/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = "~> 2.7"
-    google-beta = "~> 2.7"
+    google      = ">= 2.7, <4.0"
+    google-beta = ">= 2.7, <4.0"
   }
 }

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -16,7 +16,7 @@
 
 provider "google" {
 
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/instance_template/additional_disks/main.tf
+++ b/examples/instance_template/additional_disks/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/instance_template/simple/main.tf
+++ b/examples/instance_template/simple/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 resource "google_compute_address" "ip_address" {

--- a/examples/mig/autoscaler/main.tf
+++ b/examples/mig/autoscaler/main.tf
@@ -18,14 +18,14 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~>3.0"
 }
 
 provider "google-beta" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/mig/full/main.tf
+++ b/examples/mig/full/main.tf
@@ -18,14 +18,14 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~>3.0"
 }
 
 provider "google-beta" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/mig/simple/main.tf
+++ b/examples/mig/simple/main.tf
@@ -17,13 +17,13 @@
 provider "google" {
 
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 provider "google-beta" {
 
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/mig_with_percent/simple/README.md
+++ b/examples/mig_with_percent/simple/README.md
@@ -17,7 +17,9 @@ managed instance group.
 
 | Name | Description |
 |------|-------------|
+| preemptible\_self\_link | Self-link of preemptible instance template |
 | region | The GCP region to create and test resources in |
+| regular\_self\_link | Self-link of regular instance template |
 | self\_link | Self-link of the managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/mig_with_percent/simple/main.tf
+++ b/examples/mig_with_percent/simple/main.tf
@@ -18,14 +18,14 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.11"
+  version = "~> 3.0"
 }
 
 provider "google-beta" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.11"
+  version = "~> 3.0"
 }
 
 module "preemptible_and_regular_instance_templates" {

--- a/examples/mig_with_percent/simple/outputs.tf
+++ b/examples/mig_with_percent/simple/outputs.tf
@@ -23,3 +23,13 @@ output "region" {
   description = "The GCP region to create and test resources in"
   value       = var.region
 }
+
+output "preemptible_self_link" {
+  description = "Self-link of preemptible instance template"
+  value       = module.preemptible_and_regular_instance_templates.preemptible_self_link
+}
+
+output "regular_self_link" {
+  description = "Self-link of regular instance template"
+  value       = module.preemptible_and_regular_instance_templates.regular_self_link
+}

--- a/examples/preemptible_and_regular_instance_templates/simple/main.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.11"
+  version = "~> 3.0"
 }
 
 module "preemptible_and_regular_instance_templates" {

--- a/examples/umig/full/main.tf
+++ b/examples/umig/full/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 resource "google_compute_address" "ip_address" {

--- a/examples/umig/named_ports/main.tf
+++ b/examples/umig/named_ports/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/umig/simple/main.tf
+++ b/examples/umig/simple/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/examples/umig/static_ips/main.tf
+++ b/examples/umig/static_ips/main.tf
@@ -18,7 +18,7 @@ provider "google" {
 
   project = var.project_id
   region  = var.region
-  version = "~> 2.7.0"
+  version = "~> 3.0"
 }
 
 module "instance_template" {

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google = "~> 2.7"
+    google = ">= 2.7, <4.0"
   }
 }

--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google = "~> 2.7"
+    google = ">= 2.7, <4.0"
   }
 }

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = "~> 2.7"
-    google-beta = "~> 2.7"
+    google      = ">= 2.7, <4.0"
+    google-beta = ">= 2.7, <4.0"
   }
 }

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -17,7 +17,7 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google      = "~> 2.7"
-    google-beta = "~> 2.7"
+    google      = ">= 2.7, <4.0"
+    google-beta = ">= 2.7, <4.0"
   }
 }

--- a/modules/umig/versions.tf
+++ b/modules/umig/versions.tf
@@ -17,6 +17,6 @@
 terraform {
   required_version = "~> 0.12.6"
   required_providers {
-    google = "~> 2.7"
+    google = ">= 2.7, <4.0"
   }
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -15,11 +15,11 @@
  */
 
 provider "google" {
-  version = "~> 2.12.0"
+  version = "~> 3.0"
 }
 
 provider "google-beta" {
-  version = "~> 2.12.0"
+  version = "~> 3.0"
 }
 
 provider "null" {
@@ -32,7 +32,7 @@ provider "random" {
 
 module "project_ci_vm" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 3.0"
+  version = "~> 7.0"
 
   name              = "ci-vm-module"
   random_project_id = true


### PR DESCRIPTION
- Modules: Upgrade allowed Google provider from ~>2.7 to ">=2.7, <4.0"
- Examples: Passed from ~>2.x to ~>3.0
- 2 outputs added to the mig_with_percent example, to correct a failing test (because the instances were "about to be created" when tested)
- main.tf template modified to pass the lint tests

ran:
- examples individually
- integration tests
- generate_modules
- generate_docs
- test_lint

Please don't hesitate if I missed something or if it should be done differently