### PR TITLE
Added project attribute in google_compute_zones data source

### DIFF
--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -29,7 +29,8 @@ locals {
 }
 
 data "google_compute_zones" "available" {
-  region = var.region
+  region  = var.region
+  project = var.project_id
 }
 
 resource "google_compute_region_instance_group_manager" "mig_with_percent" {


### PR DESCRIPTION
Fixes #88 

- Added project attribute in google_compute_zones data source in mig_with_percent module so that it does not derive project ID from provider

