### PR TITLE
add outputs for compute_instance module

### DIFF
--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -31,5 +31,7 @@ See the [simple](examples/compute_instance/simple) for a usage example.
 |------|-------------|
 | available\_zones | List of available zones in region |
 | instances\_self\_links | List of self-links for compute instances |
+| ip\_list\_by\_instance | List of IP addresses for each instance by name |
+| names | List of compute instance names |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/compute_instance/outputs.tf
+++ b/modules/compute_instance/outputs.tf
@@ -26,7 +26,7 @@ output "names" {
 
 output "ip_list_by_instance" {
   description = "List of IP addresses for each instance by name"
-  value       = { for instance in google_compute_instance_from_template.compute_instance: instance["name"] => [ for nic in instance["network_interface"]: nic["network_ip"] ] }
+  value       = { for instance in google_compute_instance_from_template.compute_instance : instance["name"] => [for nic in instance["network_interface"] : nic["network_ip"]] }
 }
 
 output "available_zones" {

--- a/modules/compute_instance/outputs.tf
+++ b/modules/compute_instance/outputs.tf
@@ -19,8 +19,17 @@ output "instances_self_links" {
   value       = google_compute_instance_from_template.compute_instance.*.self_link
 }
 
+output "names" {
+  description = "List of compute instance names"
+  value       = google_compute_instance_from_template.compute_instance.*.name
+}
+
+output "ip_list_by_instance" {
+  description = "List of IP addresses for each instance by name"
+  value       = { for instance in google_compute_instance_from_template.compute_instance: instance["name"] => [ for nic in instance["network_interface"]: nic["network_ip"] ] }
+}
+
 output "available_zones" {
   description = "List of available zones in region"
   value       = data.google_compute_zones.available.names
 }
-


### PR DESCRIPTION
created outputs to enable a user to get the name on an instance as well as the ip(s) associated with an instance