### PR TITLE
terraform version upgrade for compute_instance module from 0.12.6 to …

### DIFF
--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.12.7"
   required_providers {
     google = ">= 2.7, <4.0"
   }


### PR DESCRIPTION
[Commit 3e2c8cd](https://github.com/terraform-google-modules/terraform-google-vm/commit/3e2c8cdeb2d0e6f1fe53bc2d0a9369c9dc59f013) introduced use of `regexall` function, added in [Terraform 0.12.7](https://github.com/hashicorp/terraform/blob/v0.12.28/CHANGELOG.md#0127-august-22-2019)

Update `versions.tf` to reflect the Terraform version requirement