### PR TITLE
Remove use of function regexall

### DIFF
--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -30,6 +30,7 @@ module "instance_template" {
 module "compute_instance" {
   source            = "../../../modules/compute_instance"
   region            = var.region
+  project_id        = var.project_id
   subnetwork        = var.subnetwork
   num_instances     = var.num_instances
   hostname          = "instance-simple"

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -22,7 +22,6 @@ locals {
   # at the end of the list to work around "list does not have any elements so cannot
   # determine type" error when var.static_ips is empty
   static_ips = concat(var.static_ips, ["NOT_AN_IP"])
-  project_id = length(regexall("/projects/([^/]*)", var.instance_template)) > 0 ? flatten(regexall("/projects/([^/]*)", var.instance_template))[0] : null
 }
 
 ###############
@@ -30,7 +29,7 @@ locals {
 ###############
 
 data "google_compute_zones" "available" {
-  project = local.project_id
+  project = var.project_id
   region  = var.region
 }
 
@@ -42,7 +41,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
   provider = google
   count    = local.num_instances
   name     = "${local.hostname}-${format("%03d", count.index + 1)}"
-  project  = local.project_id
+  project  = var.project_id
   zone     = data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)]
 
   network_interface {

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -14,6 +14,12 @@
  * limitations under the License.
  */
 
+variable "project_id" {
+  type        = string
+  description = "The GCP project ID"
+  default     = null
+}
+
 variable "network" {
   description = "Network to deploy to. Only one of network or subnetwork should be specified."
   default     = ""

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.7"
+  required_version = "~> 0.12.6"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = "~> 0.12.7"
   required_providers {
     google = ">= 2.7, <4.0"
   }


### PR DESCRIPTION
[Commit 3e2c8cd](https://github.com/terraform-google-modules/terraform-google-vm/commit/3e2c8cdeb2d0e6f1fe53bc2d0a9369c9dc59f013) introduced use of `regexall` function, added in [Terraform 0.12.7](https://github.com/hashicorp/terraform/blob/v0.12.28/CHANGELOG.md#0127-august-22-2019)

Removed `regexall` to stay align with other CFT module dependency on Terraform `0.12.6`, using variable `project_id` instead