### PR TITLE
fix: relax version constraints to enable terraform 0.13.x compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@
 ---
 driver:
   name: terraform
+  verify_version: false
 
 provisioner:
   name: terraform

--- a/autogen/versions.tf
+++ b/autogen/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/examples/compute_instance/simple/versions.tf
+++ b/examples/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/additional_disks/versions.tf
+++ b/examples/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/simple/versions.tf
+++ b/examples/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/autoscaler/versions.tf
+++ b/examples/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/full/versions.tf
+++ b/examples/mig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/simple/versions.tf
+++ b/examples/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig_with_percent/simple/versions.tf
+++ b/examples/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/full/versions.tf
+++ b/examples/umig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/named_ports/versions.tf
+++ b/examples/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/simple/versions.tf
+++ b/examples/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/static_ips/versions.tf
+++ b/examples/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/preemptible_and_regular_instance_templates/versions.tf
+++ b/modules/preemptible_and_regular_instance_templates/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/umig/versions.tf
+++ b/modules/umig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/test/fixtures/compute_instance/simple/versions.tf
+++ b/test/fixtures/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/additional_disks/versions.tf
+++ b/test/fixtures/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/simple/versions.tf
+++ b/test/fixtures/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/autoscaler/versions.tf
+++ b/test/fixtures/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/simple/versions.tf
+++ b/test/fixtures/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig_with_percent/simple/versions.tf
+++ b/test/fixtures/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/named_ports/versions.tf
+++ b/test/fixtures/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/simple/versions.tf
+++ b/test/fixtures/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/static_ips/versions.tf
+++ b/test/fixtures/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,13 +32,14 @@ provider "random" {
 
 module "project_ci_vm" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 7.0"
+  version = "~> 9.0"
 
-  name              = "ci-vm-module"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-vm-module"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }


### PR DESCRIPTION
## What is this change?

This change relaxes terraform version requirements, enabling terraform 0.13.x to use this module again.

## Why make this change?

This is a stopgap change intended to bridge the transition between terraform 0.12.x and 0.13.y.

## Potential gotcha

I haven't tested all the submodules and one difference I've seen between 0.12 and 0.13 are the values of `depends_on` blocks which now drop the third field - the resource attribute. Specifically, `mig_with_percent` has a `depends_on` meta-arg in the [old style](https://github.com/terraform-google-modules/terraform-google-vm/blob/master/autogen/main.tf.tmpl#L155) (docs [link](https://www.terraform.io/docs/configuration/resources.html#depends_on-explicit-resource-dependencies) on the new style). I'm not entirely sure that the old form is incompatible (encountered an error of this flavor when using the 0.13 RC builds) nor I have I tested/spent enough time in the upgrade trenches to know for sure. Let me know if you have any insight here. Let's see how CI does. 🤞 