### PR TITLE
fix(UMIG): access_config should be 2D array

### DIFF
--- a/examples/umig/full/main.tf
+++ b/examples/umig/full/main.tf
@@ -73,5 +73,5 @@ module "umig" {
   instance_template  = module.instance_template.self_link
   named_ports        = var.named_ports
   region             = var.region
-  access_config      = [local.access_config]
+  access_config      = [[local.access_config]]
 }

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -56,7 +56,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
 
     dynamic "access_config" {
-      for_each = var.access_config
+      for_each = var.access_config[count.index]
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -57,7 +57,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
 
     dynamic "access_config" {
       # convert to map to use lookup function with default value
-      for_each = lookup({ for k, v in var.access_config: k => v }, count.index, [])
+      for_each = lookup({ for k, v in var.access_config : k => v }, count.index, [])
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -57,7 +57,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
 
     dynamic "access_config" {
       # convert to map to use lookup function with default value
-      for_each = lookup({for k, v in var.access_config: k => v}, count.index, [])
+      for_each = lookup({ for k, v in var.access_config: k => v }, count.index, [])
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -56,7 +56,8 @@ resource "google_compute_instance_from_template" "compute_instance" {
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
 
     dynamic "access_config" {
-      for_each = var.access_config[count.index]
+      # convert to map to use lookup function with default value
+      for_each = lookup({for k, v in var.access_config: k => v}, count.index, [])
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -71,9 +71,9 @@ variable "instance_template" {
 
 variable "access_config" {
   description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
-  type = list(object({
+  type = list(list(object({
     nat_ip       = string
     network_tier = string
-  }))
+  })))
   default = []
 }


### PR DESCRIPTION
**Problem:**

Currently it is not possible to have multiple instances with predefined access configs (external ips). If one would want to create 3 instances with 3 external ips, each instance would get same 3 predefined external ips. Which is not possible. 

**Solution:**

Make `access_config` 2D array, so each instance would get an array of predefined ips.