### PR TITLE
adds an output for the health check self_links to be consumed by load balancer resources outside this module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.12.2
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.{{ module_name }}
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.2'

--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -6,14 +6,14 @@ This is a simple, minimal example of how to use the compute_instance module
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| nat\_ip | Public ip address | string | `"null"` | no |
-| network\_tier | Network network_tier | string | `"PREMIUM"` | no |
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork selflink to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| nat\_ip | Public ip address | `any` | `null` | no |
+| network\_tier | Network network\_tier | `string` | `"PREMIUM"` | no |
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string,<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork selflink to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/instance_template/additional_disks/README.md
+++ b/examples/instance_template/additional_disks/README.md
@@ -7,11 +7,11 @@ instance templates with additional persistent disks.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
 
 ## Outputs
 

--- a/examples/instance_template/simple/README.md
+++ b/examples/instance_template/simple/README.md
@@ -6,13 +6,13 @@ This is a simple, minimal example of how to use the instance_template module.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| labels | Labels, provided as a map | map(string) | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| labels | Labels, provided as a map | `map(string)` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig/autoscaler/README.md
+++ b/examples/mig/autoscaler/README.md
@@ -7,14 +7,14 @@ group with an autoscaler.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | n/a | yes |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | n/a | yes |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | n/a | yes |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `any` | n/a | yes |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig/simple/README.md
+++ b/examples/mig/simple/README.md
@@ -7,12 +7,12 @@ managed instance group.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/mig_with_percent/simple/README.md
+++ b/examples/mig_with_percent/simple/README.md
@@ -7,11 +7,11 @@ managed instance group.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account email address and scopes | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account email address and scopes | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/preemptible_and_regular_instance_templates/simple/README.md
+++ b/examples/preemptible_and_regular_instance_templates/simple/README.md
@@ -6,13 +6,13 @@ This creates instance templates for both preemptible VM and regular VM
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| labels | Labels, provided as a map | map(string) | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The name of the subnetwork create this instance in. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| labels | Labels, provided as a map | `map(string)` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The name of the subnetwork create this instance in. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/named_ports/README.md
+++ b/examples/umig/named_ports/README.md
@@ -7,13 +7,13 @@ groups with named ports
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| named\_ports | Named name and named port | object | `<list>` | no |
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/simple/README.md
+++ b/examples/umig/simple/README.md
@@ -6,12 +6,12 @@ This is a simple, minimal example of how to use the UMIG module
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| num\_instances | Number of instances to create | string | n/a | yes |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| num\_instances | Number of instances to create | `any` | n/a | yes |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/examples/umig/static_ips/README.md
+++ b/examples/umig/static_ips/README.md
@@ -7,13 +7,13 @@ instance groups with user-specified static IPs.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| num\_instances | Number of instances to create | string | `"1"` | no |
-| project\_id | The GCP project to use for integration tests | string | n/a | yes |
-| region | The GCP region to create and test resources in | string | `"us-central1"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | `"null"` | no |
-| static\_ips | List of static IPs for VM instances | list(string) | n/a | yes |
-| subnetwork | The subnetwork to host the compute instances in | string | n/a | yes |
+|------|-------------|------|---------|:--------:|
+| num\_instances | Number of instances to create | `string` | `"1"` | no |
+| project\_id | The GCP project to use for integration tests | `string` | n/a | yes |
+| region | The GCP region to create and test resources in | `string` | `"us-central1"` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | `null` | no |
+| static\_ips | List of static IPs for VM instances | `list(string)` | n/a | yes |
+| subnetwork | The subnetwork to host the compute instances in | `any` | n/a | yes |
 
 ## Outputs
 

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -14,16 +14,16 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| hostname | Hostname of instances | string | `""` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| num\_instances | Number of instances to create. This value is ignored if static_ips is provided. | string | `"1"` | no |
-| region | Region where the instances should be created. | string | `"null"` | no |
-| static\_ips | List of static IPs for VM instances | list(string) | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| hostname | Hostname of instances | `string` | `""` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |
+| region | Region where the instances should be created. | `string` | `null` | no |
+| static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
 
 ## Outputs
 

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -14,31 +14,31 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | object | `<list>` | no |
-| auto\_delete | Whether or not the boot disk should be auto-deleted | string | `"true"` | no |
-| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | string | `"false"` | no |
-| disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
-| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |
-| enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | string | `"false"` | no |
-| labels | Labels, provided as a map | map(string) | `<map>` | no |
-| machine\_type | Machine type to create, e.g. n1-standard-1 | string | `"n1-standard-1"` | no |
-| metadata | Metadata, provided as a map | map(string) | `<map>` | no |
-| name\_prefix | Name prefix for the instance template | string | `"default-instance-template"` | no |
-| network | The name or self_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | string | `""` | no |
-| preemptible | Allow the instance to be preempted | bool | `"false"` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | Region where the instance template should be created. | string | `"null"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | n/a | yes |
-| shielded\_instance\_config | Not used unless enable_shielded_vm is true. Shielded VM configuration for the instance. | object | `<map>` | no |
-| source\_image | Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_family | Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `"centos-7"` | no |
-| source\_image\_project | Project where the source image comes from. The default project contains images that support Shielded VMs if desired | string | `"gce-uefi-images"` | no |
-| startup\_script | User startup script to run when instances spin up | string | `""` | no |
-| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | string | `""` | no |
-| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | `<list>` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| auto\_delete | Whether or not the boot disk should be auto-deleted | `string` | `"true"` | no |
+| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
+| disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
+| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
+| labels | Labels, provided as a map | `map(string)` | `{}` | no |
+| machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
+| metadata | Metadata, provided as a map | `map(string)` | `{}` | no |
+| name\_prefix | Name prefix for the instance template | `string` | `"default-instance-template"` | no |
+| network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
+| preemptible | Allow the instance to be preempted | `bool` | `false` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | Region where the instance template should be created. | `string` | `null` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| shielded\_instance\_config | Not used unless enable\_shielded\_vm is true. Shielded VM configuration for the instance. | <pre>object({<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>    enable_integrity_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
+| source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `"centos-7"` | no |
+| source\_image\_project | Project where the source image comes from. The default project contains images that support Shielded VMs if desired | `string` | `"gce-uefi-images"` | no |
+| startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
+| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
+| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -17,37 +17,38 @@ The current version is 2.X. The following guides are available to assist with up
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | `"false"` | no |
-| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | object | `<list>` | no |
-| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | string | `"60"` | no |
-| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | list(string) | `<list>` | no |
-| health\_check | Health check to determine whether instances are responsive and able to do work | object | `<map>` | no |
-| hostname | Hostname prefix for instances | string | `"default"` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
-| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
-| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the managed instance group resides. | string | n/a | yes |
-| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
-| target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
-| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
-| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `string` | `"false"` | no |
+| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | <pre>list(object({<br>    name   = string<br>    target = number<br>    type   = string<br>  }))</pre> | `[]` | no |
+| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | `number` | `60` | no |
+| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | `list(string)` | `[]` | no |
+| health\_check | Health check to determine whether instances are responsive and able to do work | <pre>object({<br>    type                = string<br>    initial_delay_sec   = number<br>    check_interval_sec  = number<br>    healthy_threshold   = number<br>    timeout_sec         = number<br>    unhealthy_threshold = number<br>    response            = string<br>    proxy_header        = string<br>    port                = number<br>    request             = string<br>    request_path        = string<br>    host                = string<br>  })</pre> | <pre>{<br>  "check_interval_sec": 30,<br>  "healthy_threshold": 1,<br>  "host": "",<br>  "initial_delay_sec": 30,<br>  "port": 80,<br>  "proxy_header": "NONE",<br>  "request": "",<br>  "request_path": "/",<br>  "response": "",<br>  "timeout_sec": 10,<br>  "type": "",<br>  "unhealthy_threshold": 5<br>}</pre> | no |
+| hostname | Hostname prefix for instances | `string` | `"default"` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
+| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the managed instance group resides. | `any` | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | <pre>list(object({<br>    device_name = string<br>    delete_rule = string<br>  }))</pre> | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
+| target\_pools | The target load balancing pools to assign this group to. | `list(string)` | `[]` | no |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `number` | `1` | no |
+| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | <pre>list(object({<br>    max_surge_fixed              = number<br>    instance_redistribution_type = string<br>    max_surge_percent            = number<br>    max_unavailable_fixed        = number<br>    max_unavailable_percent      = number<br>    min_ready_sec                = number<br>    minimal_action               = string<br>    type                         = string<br>  }))</pre> | `[]` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | `string` | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| health\_check\_self\_links | All self\_links of healthchecks created for the instance group. |
 | instance\_group | Instance-group url of managed instance group |
-| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
+| instance\_group\_manager | An instance of google\_compute\_region\_instance\_group\_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.mig
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -16,39 +16,40 @@ The current version is 2.X. The following guides are available to assist with up
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_enabled | Creates an autoscaler for the managed instance group | string | `"false"` | no |
-| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | list(map(number)) | `<list>` | no |
-| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | object | `<list>` | no |
-| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | string | `"60"` | no |
-| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | list(string) | `<list>` | no |
-| health\_check | Health check to determine whether instances are responsive and able to do work | object | `<map>` | no |
-| hostname | Hostname prefix for instances | string | `"default"` | no |
-| instance\_template\_initial\_version | Instance template self_link used to create compute instances for the initial version | string | n/a | yes |
-| instance\_template\_next\_version | Instance template self_link used to create compute instances for the second version | string | n/a | yes |
-| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
-| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
-| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
-| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| next\_version\_percent | Percentage of instances defined in the second version | string | n/a | yes |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the managed instance group resides. | string | n/a | yes |
-| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
-| target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
-| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
-| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
-| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
+|------|-------------|------|---------|:--------:|
+| autoscaling\_cpu | Autoscaling, cpu utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#cpu_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_enabled | Creates an autoscaler for the managed instance group | `string` | `"false"` | no |
+| autoscaling\_lb | Autoscaling, load balancing utilization policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#load_balancing_utilization | `list(map(number))` | `[]` | no |
+| autoscaling\_metric | Autoscaling, metric policy block as single element array. https://www.terraform.io/docs/providers/google/r/compute_autoscaler.html#metric | <pre>list(object({<br>    name   = string<br>    target = number<br>    type   = string<br>  }))</pre> | `[]` | no |
+| cooldown\_period | The number of seconds that the autoscaler should wait before it starts collecting information from a new instance. | `number` | `60` | no |
+| distribution\_policy\_zones | The distribution policy, i.e. which zone(s) should instances be create in. Default is all zones in given region. | `list(string)` | `[]` | no |
+| health\_check | Health check to determine whether instances are responsive and able to do work | <pre>object({<br>    type                = string<br>    initial_delay_sec   = number<br>    check_interval_sec  = number<br>    healthy_threshold   = number<br>    timeout_sec         = number<br>    unhealthy_threshold = number<br>    response            = string<br>    proxy_header        = string<br>    port                = number<br>    request             = string<br>    request_path        = string<br>    host                = string<br>  })</pre> | <pre>{<br>  "check_interval_sec": 30,<br>  "healthy_threshold": 1,<br>  "host": "",<br>  "initial_delay_sec": 30,<br>  "port": 80,<br>  "proxy_header": "NONE",<br>  "request": "",<br>  "request_path": "/",<br>  "response": "",<br>  "timeout_sec": 10,<br>  "type": "",<br>  "unhealthy_threshold": 5<br>}</pre> | no |
+| hostname | Hostname prefix for instances | `string` | `"default"` | no |
+| instance\_template\_initial\_version | Instance template self\_link used to create compute instances for the initial version | `any` | n/a | yes |
+| instance\_template\_next\_version | Instance template self\_link used to create compute instances for the second version | `any` | n/a | yes |
+| max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
+| min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
+| named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| next\_version\_percent | Percentage of instances defined in the second version | `any` | n/a | yes |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the managed instance group resides. | `any` | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | <pre>list(object({<br>    device_name = string<br>    delete_rule = string<br>  }))</pre> | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
+| target\_pools | The target load balancing pools to assign this group to. | `list(string)` | `[]` | no |
+| target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | `number` | `1` | no |
+| update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | <pre>list(object({<br>    max_surge_fixed              = number<br>    instance_redistribution_type = string<br>    max_surge_percent            = number<br>    max_unavailable_fixed        = number<br>    max_unavailable_percent      = number<br>    min_ready_sec                = number<br>    minimal_action               = string<br>    type                         = string<br>  }))</pre> | `[]` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | `string` | `"false"` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
+| health\_check\_self\_links | All self\_links of healthchecks created for the instance group. |
 | instance\_group | Instance-group url of managed instance group |
-| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
+| instance\_group\_manager | An instance of google\_compute\_region\_instance\_group\_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig_with_percent/outputs.tf
+++ b/modules/mig_with_percent/outputs.tf
@@ -30,3 +30,8 @@ output "instance_group_manager" {
   description = "An instance of google_compute_region_instance_group_manager of the instance group."
   value       = google_compute_region_instance_group_manager.mig_with_percent
 }
+
+output "health_check_self_links" {
+  description = "All self_links of healthchecks created for the instance group."
+  value       = local.healthchecks
+}

--- a/modules/preemptible_and_regular_instance_templates/README.md
+++ b/modules/preemptible_and_regular_instance_templates/README.md
@@ -11,27 +11,27 @@ See the [simple](../../examples/preemptible_and_regular_instance_templates/simpl
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | object | `<list>` | no |
-| auto\_delete | Whether or not the boot disk should be auto-deleted | string | `"true"` | no |
-| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | string | `"false"` | no |
-| disk\_size\_gb | Boot disk size in GB | string | `"100"` | no |
-| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | string | `"pd-standard"` | no |
-| labels | Labels, provided as a map | map(string) | `<map>` | no |
-| machine\_type | Machine type to create, e.g. n1-standard-1 | string | `"n1-standard-1"` | no |
-| metadata | Metadata, provided as a map | map(string) | `<map>` | no |
-| name\_prefix | Name prefix for the instance template | string | `"default-it"` | no |
-| network | The name or self_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | string | `""` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | object | n/a | yes |
-| source\_image | Source disk image. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_family | Source image family. If neither source_image nor source_image_family is specified, defaults to the latest public CentOS image. | string | `""` | no |
-| source\_image\_project | Project where the source image comes from | string | `""` | no |
-| startup\_script | User startup script to run when instances spin up | string | `""` | no |
-| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | string | `""` | no |
-| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | string | `""` | no |
-| tags | Network tags, provided as a list | list(string) | `<list>` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| auto\_delete | Whether or not the boot disk should be auto-deleted | `bool` | `true` | no |
+| can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
+| disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
+| disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| labels | Labels, provided as a map | `map(string)` | `{}` | no |
+| machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
+| metadata | Metadata, provided as a map | `map(string)` | `{}` | no |
+| name\_prefix | Name prefix for the instance template | `string` | `"default-it"` | no |
+| network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
+| source\_image\_project | Project where the source image comes from | `string` | `""` | no |
+| startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
+| subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
+| subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
+| tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs
 

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -14,18 +14,18 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
-| hostname | Hostname of instances | string | `""` | no |
-| instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
-| named\_ports | Named name and named port | object | `<list>` | no |
-| network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| num\_instances | Number of instances to create. This value is ignored if static_ips is provided. | string | `"1"` | no |
-| project\_id | The GCP project ID | string | `"null"` | no |
-| region | The GCP region where the unmanaged instance group resides. | string | n/a | yes |
-| static\_ips | List of static IPs for VM instances | list(string) | `<list>` | no |
-| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
-| subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
+|------|-------------|------|---------|:--------:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  })))</pre> | `[]` | no |
+| hostname | Hostname of instances | `string` | `""` | no |
+| instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
+| named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
+| network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |
+| project\_id | The GCP project ID | `string` | `null` | no |
+| region | The GCP region where the unmanaged instance group resides. | `string` | n/a | yes |
+| static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
+| subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
+| subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
 
 ## Outputs
 


### PR DESCRIPTION
## What is this change?

This change adds an output of the health_check.

## Why make this change?

Without this output, one has to conventionally construct a self-link when consumed by a `google_compute_region_backend_service`. This gives a simpler way to connect that resource with this module.