### PR TITLE
Disk name

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -15,6 +15,7 @@
 ---
 driver:
   name: terraform
+  verify_version: false
 
 provisioner:
   name: terraform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [5.1.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v5.0.0...v5.1.0) (2020-10-07)
+
+
+### Features
+
+* Added instance_group_manager output ([#105](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/105)) ([e8a174a](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/e8a174aa899f9ade792d1576689603eab6ca774e))
+
 ## [5.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v4.0.0...v5.0.0) (2020-09-15)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [4.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v3.0.0...v4.0.0) (2020-06-23)
+
+
+### ⚠ BREAKING CHANGES
+
+* instance_redistribution_type must now be specified for update policies.
+
+### Features
+
+* Add stateful disk support ([#90](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/90)) ([645e845](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/645e8453e945fe6f7b1c5cccd7ad557f5355cc10))
+* Add wait_for_instances and configurable timeout support for mig ([#96](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/96)) ([10a23b7](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/10a23b70250bd26ed9820184b535e4ce99d24ec7))
+
 ## [3.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.1.0...v3.0.0) (2020-05-27)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [5.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v4.0.0...v5.0.0) (2020-09-15)
+
+
+### ⚠ BREAKING CHANGES
+
+* **UMIG:** var.access_config has been changed to a 2D array, with a separate element for each VM.
+
+### Bug Fixes
+
+* **UMIG:** access_config should be 2D array ([#111](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/111)) ([69f7520](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/69f752033453ceb2ee50a8d5614112ce96b60650))
+* relax version constraints to enable terraform 0.13.x compatibility ([#108](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/108)) ([6fb2b42](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/6fb2b42bd96f90d3c2baffd511cb58200fbc074c))
+* Terraform version upgrade for compute_instance module from 0.12.6 to 0.12.7 ([#103](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/103)) ([7a21e78](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/7a21e788f6ded801be8d3354bfd31934aca5b7fb))
+
 ## [4.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v3.0.0...v4.0.0) (2020-06-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [conventional-commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## [3.0.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.1.0...v3.0.0) (2020-05-27)
+
+
+### ⚠ BREAKING CHANGES
+
+* The preemptible_and_regular_instance_templates modules have had name_prefixes renamed, forcing instances to be recreated.
+
+### Features
+
+* Add support for assigning public IPs directly to instances. ([#83](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/83)) ([dde01ff](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/dde01ff376a8e58b4a365724cb4531a4e24435a5))
+
+
+### Bug Fixes
+
+* Correct names for instances in preemptible and regular instance module ([#81](https://www.github.com/terraform-google-modules/terraform-google-vm/issues/81)) ([5a6ec12](https://www.github.com/terraform-google-modules/terraform-google-vm/commit/5a6ec12c3d26c88e45fe4b1a1d919562b4995f24))
+
 ## [2.1.0](https://www.github.com/terraform-google-modules/terraform-google-vm/compare/v2.0.0...v2.1.0) (2020-03-05)
 
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -71,6 +71,8 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -91,19 +93,26 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 
@@ -143,7 +152,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   }
   {% if mig_with_percent %}
 
-  depends_on = ["google_compute_region_instance_group_manager.mig_with_percent"]
+  depends_on = [google_compute_region_instance_group_manager.mig_with_percent]
   {% endif %}
 }
 

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -79,6 +79,14 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -106,7 +106,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.{{ module_name }}.self_link
+  target = google_compute_region_instance_group_manager.{{ module_name }}.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -29,12 +29,8 @@ locals {
 }
 
 data "google_compute_zones" "available" {
-  {% if mig %}
   project = var.project_id
   region  = var.region
-  {% else %}
-  region = var.region
-  {% endif %}
 }
 
 resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
@@ -108,9 +104,8 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   count    = var.autoscaling_enabled ? 1 : 0
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
-  {% if mig %}
   region   = var.region
-  {% endif %}
+
   target   = google_compute_region_instance_group_manager.{{ module_name }}.self_link
 
   autoscaling_policy {

--- a/autogen/outputs.tf.tmpl
+++ b/autogen/outputs.tf.tmpl
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.{{ module_name }}.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.{{ module_name }}
+}

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -86,13 +86,14 @@ variable "stateful_disks" {
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -202,4 +203,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -68,6 +68,18 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+
+#################
 # Rolling Update
 #################
 

--- a/autogen/versions.tf
+++ b/autogen/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -246,4 +246,4 @@ tags:
 - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
 - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.12.0'

--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -7,6 +7,8 @@ This is a simple, minimal example of how to use the compute_instance module
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| nat\_ip | Public ip address | string | `"null"` | no |
+| network\_tier | Network network_tier | string | `"PREMIUM"` | no |
 | num\_instances | Number of instances to create | string | n/a | yes |
 | project\_id | The GCP project to use for integration tests | string | n/a | yes |
 | region | The GCP region to create and test resources in | string | `"us-central1"` | no |

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -34,4 +34,8 @@ module "compute_instance" {
   num_instances     = var.num_instances
   hostname          = "instance-simple"
   instance_template = module.instance_template.self_link
+  access_config = [{
+    nat_ip       = var.nat_ip
+    network_tier = var.network_tier
+  }, ]
 }

--- a/examples/compute_instance/simple/variables.tf
+++ b/examples/compute_instance/simple/variables.tf
@@ -35,6 +35,15 @@ variable "num_instances" {
   description = "Number of instances to create"
 }
 
+variable "nat_ip" {
+  description = "Public ip address"
+  default     = null
+}
+
+variable "network_tier" {
+  description = "Network network_tier"
+  default     = "PREMIUM"
+}
 
 
 variable "service_account" {

--- a/examples/compute_instance/simple/versions.tf
+++ b/examples/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/additional_disks/main.tf
+++ b/examples/instance_template/additional_disks/main.tf
@@ -30,18 +30,21 @@ module "instance_template" {
 
   additional_disks = [
     {
+      disk_name    = "disk-0"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
     },
     {
+      disk_name    = "disk-1"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
     },
     {
+      disk_name    = "disk-2"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"

--- a/examples/instance_template/additional_disks/versions.tf
+++ b/examples/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/instance_template/simple/versions.tf
+++ b/examples/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/autoscaler/versions.tf
+++ b/examples/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -124,6 +124,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -179,13 +179,14 @@ variable "distribution_policy_zones" {
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -268,4 +269,3 @@ variable "autoscaling_enabled" {
   type        = bool
   default     = false
 }
-

--- a/examples/mig/full/versions.tf
+++ b/examples/mig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig/simple/versions.tf
+++ b/examples/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/mig_with_percent/simple/versions.tf
+++ b/examples/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/examples/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/full/main.tf
+++ b/examples/umig/full/main.tf
@@ -73,5 +73,5 @@ module "umig" {
   instance_template  = module.instance_template.self_link
   named_ports        = var.named_ports
   region             = var.region
-  access_config      = [local.access_config]
+  access_config      = [[local.access_config]]
 }

--- a/examples/umig/full/variables.tf
+++ b/examples/umig/full/variables.tf
@@ -124,6 +124,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/examples/umig/full/versions.tf
+++ b/examples/umig/full/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/named_ports/versions.tf
+++ b/examples/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/simple/versions.tf
+++ b/examples/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/examples/umig/static_ips/versions.tf
+++ b/examples/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -5,7 +5,7 @@ This module is used to create compute instances (and only compute instances) usi
 
 ## Usage
 
-See the [simple](examples/compute_instance/simple) for a usage example.
+See the [simple](https://github.com/terraform-google-modules/terraform-google-vm/tree/master/examples/compute_instance/simple) for a usage example.
 
 ## Testing
 

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -15,6 +15,7 @@ See the [simple](examples/compute_instance/simple) for a usage example.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | object | `<list>` | no |
 | hostname | Hostname of instances | string | `""` | no |
 | instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -50,6 +50,13 @@ resource "google_compute_instance_from_template" "compute_instance" {
     subnetwork         = var.subnetwork
     subnetwork_project = var.subnetwork_project
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
+    dynamic "access_config" {
+      for_each = var.access_config
+      content {
+        nat_ip       = access_config.value.nat_ip
+        network_tier = access_config.value.network_tier
+      }
+    }
   }
 
   source_instance_template = var.instance_template

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -40,6 +40,15 @@ variable "static_ips" {
   default     = []
 }
 
+variable "access_config" {
+  description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
+  type = list(object({
+    nat_ip       = string
+    network_tier = string
+  }))
+  default = []
+}
+
 variable "num_instances" {
   description = "Number of instances to create. This value is ignored if static_ips is provided."
   default     = "1"

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/compute_instance/versions.tf
+++ b/modules/compute_instance/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">=0.12.6, <0.14"
+  required_version = ">=0.12.7, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -1,6 +1,6 @@
 # instance_template
 
-This submodule allows you to create an `google_compute_instance_template`
+This submodule allows you to create a `google_compute_instance_template`
 resource, which is used as the basis for the other instance, managed, and
 unmanaged instance groups submodules.
 

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -95,6 +95,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -47,6 +47,7 @@ The current version is 2.X. The following guides are available to assist with up
 | Name | Description |
 |------|-------------|
 | instance\_group | Instance-group url of managed instance group |
+| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -28,16 +28,19 @@ The current version is 2.X. The following guides are available to assist with up
 | hostname | Hostname prefix for instances | string | `"default"` | no |
 | instance\_template | Instance template self_link used to create compute instances | string | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | project\_id | The GCP project ID | string | `"null"` | no |
 | region | The GCP region where the managed instance group resides. | string | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
 | target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
 | target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
 | update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
 
 ## Outputs
 

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -55,6 +55,8 @@ resource "google_compute_region_instance_group_manager" "mig" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -89,6 +91,12 @@ resource "google_compute_region_instance_group_manager" "mig" {
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -90,7 +90,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.mig.self_link
+  target = google_compute_region_instance_group_manager.mig.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -89,6 +89,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
   region   = var.region
+
   target   = google_compute_region_instance_group_manager.mig.self_link
 
   autoscaling_policy {

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -63,17 +63,26 @@ resource "google_compute_region_instance_group_manager" "mig" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 

--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.mig.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.mig
+}

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -53,19 +53,31 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+#################
 # Rolling Update
 #################
 
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -63,6 +63,7 @@ variable "stateful_disks" {
   }))
   default = []
 }
+
 #################
 # Rolling Update
 #################
@@ -187,4 +188,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -48,6 +48,7 @@ The current version is 2.X. The following guides are available to assist with up
 | Name | Description |
 |------|-------------|
 | instance\_group | Instance-group url of managed instance group |
+| instance\_group\_manager | An instance of google_compute_region_instance_group_manager of the instance group. |
 | self\_link | Self-link of managed instance group |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -28,17 +28,20 @@ The current version is 2.X. The following guides are available to assist with up
 | instance\_template\_initial\_version | Instance template self_link used to create compute instances for the initial version | string | n/a | yes |
 | instance\_template\_next\_version | Instance template self_link used to create compute instances for the second version | string | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | string | `"10"` | no |
+| mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. | object | `<map>` | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | string | `"2"` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | object | `<list>` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | next\_version\_percent | Percentage of instances defined in the second version | string | n/a | yes |
 | project\_id | The GCP project ID | string | `"null"` | no |
 | region | The GCP region where the managed instance group resides. | string | n/a | yes |
+| stateful\_disks | Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs | object | `<list>` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | string | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | string | `""` | no |
 | target\_pools | The target load balancing pools to assign this group to. | list(string) | `<list>` | no |
 | target\_size | The target number of running instances for this managed instance group. This value should always be explicitly set unless this resource is attached to an autoscaler, in which case it should never be set. | string | `"1"` | no |
 | update\_policy | The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy | object | `<list>` | no |
+| wait\_for\_instances | Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out. | string | `"false"` | no |
 
 ## Outputs
 

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -64,6 +64,8 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
   target_pools = var.target_pools
   target_size  = var.autoscaling_enabled ? null : var.target_size
 
+  wait_for_instances = var.wait_for_instances
+
   dynamic "auto_healing_policies" {
     for_each = local.healthchecks
     content {
@@ -72,23 +74,38 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
     }
   }
 
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
   distribution_policy_zones = local.distribution_policy_zones
   dynamic "update_policy" {
     for_each = var.update_policy
     content {
-      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
-      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
-      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
-      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
-      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
-      minimal_action          = update_policy.value.minimal_action
-      type                    = update_policy.value.type
+      instance_redistribution_type = lookup(update_policy.value, "instance_redistribution_type", null)
+      max_surge_fixed              = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent            = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed        = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent      = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec                = lookup(update_policy.value, "min_ready_sec", null)
+      minimal_action               = update_policy.value.minimal_action
+      type                         = update_policy.value.type
     }
   }
 
   lifecycle {
     create_before_destroy = true
     ignore_changes        = [distribution_policy_zones]
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
   }
 }
 

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -124,7 +124,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
     }
   }
 
-  depends_on = ["google_compute_region_instance_group_manager.mig_with_percent"]
+  depends_on = [google_compute_region_instance_group_manager.mig_with_percent]
 }
 
 resource "google_compute_health_check" "http" {

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -99,7 +99,7 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   project  = var.project_id
   region   = var.region
 
-  target   = google_compute_region_instance_group_manager.mig_with_percent.self_link
+  target = google_compute_region_instance_group_manager.mig_with_percent.self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -29,7 +29,8 @@ locals {
 }
 
 data "google_compute_zones" "available" {
-  region = var.region
+  project = var.project_id
+  region  = var.region
 }
 
 resource "google_compute_region_instance_group_manager" "mig_with_percent" {
@@ -96,6 +97,8 @@ resource "google_compute_region_autoscaler" "autoscaler" {
   count    = var.autoscaling_enabled ? 1 : 0
   name     = "${var.hostname}-autoscaler"
   project  = var.project_id
+  region   = var.region
+
   target   = google_compute_region_instance_group_manager.mig_with_percent.self_link
 
   autoscaling_policy {

--- a/modules/mig_with_percent/outputs.tf
+++ b/modules/mig_with_percent/outputs.tf
@@ -25,3 +25,8 @@ output "instance_group" {
   description = "Instance-group url of managed instance group"
   value       = google_compute_region_instance_group_manager.mig_with_percent.instance_group
 }
+
+output "instance_group_manager" {
+  description = "An instance of google_compute_region_instance_group_manager of the instance group."
+  value       = google_compute_region_instance_group_manager.mig_with_percent
+}

--- a/modules/mig_with_percent/variables.tf
+++ b/modules/mig_with_percent/variables.tf
@@ -61,19 +61,32 @@ variable "distribution_policy_zones" {
 }
 
 #################
+# Stateful disks
+#################
+variable "stateful_disks" {
+  description = "Disks created on the instances that will be preserved on instance delete. https://cloud.google.com/compute/docs/instance-groups/configuring-stateful-disks-in-migs"
+  type = list(object({
+    device_name = string
+    delete_rule = string
+  }))
+  default = []
+}
+
+#################
 # Rolling Update
 #################
 
 variable "update_policy" {
   description = "The rolling update policy. https://www.terraform.io/docs/providers/google/r/compute_region_instance_group_manager.html#rolling_update_policy"
   type = list(object({
-    max_surge_fixed         = number
-    max_surge_percent       = number
-    max_unavailable_fixed   = number
-    max_unavailable_percent = number
-    min_ready_sec           = number
-    minimal_action          = string
-    type                    = string
+    max_surge_fixed              = number
+    instance_redistribution_type = string
+    max_surge_percent            = number
+    max_unavailable_fixed        = number
+    max_unavailable_percent      = number
+    min_ready_sec                = number
+    minimal_action               = string
+    type                         = string
   }))
   default = []
 }
@@ -183,4 +196,23 @@ variable "named_ports" {
     port = number
   }))
   default = []
+}
+
+variable "wait_for_instances" {
+  description = "Whether to wait for all instances to be created/updated before returning. Note that if this is set to true and the operation does not succeed, Terraform will continue trying until it times out."
+  default     = "false"
+}
+
+variable "mig_timeouts" {
+  description = "Times for creation, deleting and updating the MIG resources. Can be helpful when using wait_for_instances to allow a longer VM startup time. "
+  type = object({
+    create = string
+    update = string
+    delete = string
+  })
+  default = {
+    create = "5m"
+    update = "5m"
+    delete = "15m"
+  }
 }

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google      = ">= 2.7, <4.0"
     google-beta = ">= 2.7, <4.0"

--- a/modules/preemptible_and_regular_instance_templates/main.tf
+++ b/modules/preemptible_and_regular_instance_templates/main.tf
@@ -20,7 +20,7 @@
 
 module "preemptible" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-regular"
+  name_prefix          = "${var.name_prefix}-preemptible"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels
@@ -45,7 +45,7 @@ module "preemptible" {
 
 module "regular" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-preemptible"
+  name_prefix          = "${var.name_prefix}-regular"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels

--- a/modules/preemptible_and_regular_instance_templates/main.tf
+++ b/modules/preemptible_and_regular_instance_templates/main.tf
@@ -20,7 +20,7 @@
 
 module "preemptible" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-preemptible"
+  name_prefix          = "${var.name_prefix}-regular"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels
@@ -45,7 +45,7 @@ module "preemptible" {
 
 module "regular" {
   source               = "../../modules/instance_template"
-  name_prefix          = "${var.name_prefix}-regular"
+  name_prefix          = "${var.name_prefix}-preemptible"
   project_id           = var.project_id
   machine_type         = var.machine_type
   labels               = var.labels

--- a/modules/preemptible_and_regular_instance_templates/variables.tf
+++ b/modules/preemptible_and_regular_instance_templates/variables.tf
@@ -83,6 +83,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/modules/preemptible_and_regular_instance_templates/versions.tf
+++ b/modules/preemptible_and_regular_instance_templates/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -5,7 +5,7 @@ This module is used to create compute instances using
 
 ## Usage
 
-See the [simple](examples/umig/simple) for a usage example.
+See the [simple](https://github.com/terraform-google-modules/terraform-google-vm/tree/master/examples/umig/simple) for a usage example.
 
 ## Testing
 

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -56,7 +56,8 @@ resource "google_compute_instance_from_template" "compute_instance" {
     network_ip         = length(var.static_ips) == 0 ? "" : element(local.static_ips, count.index)
 
     dynamic "access_config" {
-      for_each = var.access_config
+      # convert to map to use lookup function with default value
+      for_each = lookup({ for k, v in var.access_config : k => v }, count.index, [])
       content {
         nat_ip       = access_config.value.nat_ip
         network_tier = access_config.value.network_tier

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -71,9 +71,9 @@ variable "instance_template" {
 
 variable "access_config" {
   description = "Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet."
-  type = list(object({
+  type = list(list(object({
     nat_ip       = string
     network_tier = string
-  }))
+  })))
   default = []
 }

--- a/modules/umig/versions.tf
+++ b/modules/umig/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
   required_providers {
     google = ">= 2.7, <4.0"
   }

--- a/test/fixtures/compute_instance/simple/versions.tf
+++ b/test/fixtures/compute_instance/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/additional_disks/versions.tf
+++ b/test/fixtures/instance_template/additional_disks/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/instance_template/simple/versions.tf
+++ b/test/fixtures/instance_template/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/autoscaler/versions.tf
+++ b/test/fixtures/mig/autoscaler/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig/simple/versions.tf
+++ b/test/fixtures/mig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/mig_with_percent/simple/versions.tf
+++ b/test/fixtures/mig_with_percent/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
+++ b/test/fixtures/preemptible_and_regular_instance_templates/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/named_ports/versions.tf
+++ b/test/fixtures/umig/named_ports/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/simple/versions.tf
+++ b/test/fixtures/umig/simple/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/fixtures/umig/static_ips/versions.tf
+++ b/test/fixtures/umig/static_ips/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }

--- a/test/integration/preemptible_and_regular_instance_templates_simple/controls/simple.rb
+++ b/test/integration/preemptible_and_regular_instance_templates_simple/controls/simple.rb
@@ -34,8 +34,8 @@ control "Instance Template" do
 
     describe "kind of templates" do
       it "should be #{expected_disks}" do
-        expect(data[0]['properties']['scheduling']['preemptible']).to be_truthy
-        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_falsey
+        expect(data[0]['properties']['scheduling']['preemptible']).to be_falsey
+        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_truthy
       end
     end
 
@@ -90,8 +90,8 @@ control "Instance Template" do
 
     describe "kind of templates" do
       it "should be #{expected_disks}" do
-        expect(data[0]['properties']['scheduling']['preemptible']).to be_falsey
-        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_truthy
+        expect(data[0]['properties']['scheduling']['preemptible']).to be_truthy
+        expect(data[0]['properties']['scheduling']['automaticRestart']).to be_falsey
       end
     end
 

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -32,13 +32,14 @@ provider "random" {
 
 module "project_ci_vm" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 7.0"
+  version = "~> 9.0"
 
-  name              = "ci-vm-module"
-  random_project_id = true
-  org_id            = var.org_id
-  folder_id         = var.folder_id
-  billing_account   = var.billing_account
+  name                 = "ci-vm-module"
+  random_project_id    = true
+  org_id               = var.org_id
+  folder_id            = var.folder_id
+  billing_account      = var.billing_account
+  skip_gcloud_download = true
 
   activate_apis = [
     "cloudresourcemanager.googleapis.com",

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = "~> 0.12.6"
+  required_version = ">=0.12.6, <0.14"
 }


### PR DESCRIPTION
Remove deprecation message.
Allow use of disk_name so additional disks can be referenced in other code. 
eg. in google_compute_disk_resource_policy_attachment for snapshotting disks.