### PR TITLE
Disk: Allow use of disk_name for additional disks

### DIFF
--- a/examples/instance_template/additional_disks/main.tf
+++ b/examples/instance_template/additional_disks/main.tf
@@ -30,18 +30,21 @@ module "instance_template" {
 
   additional_disks = [
     {
+      disk_name    = "disk-0"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
     },
     {
+      disk_name    = "disk-1"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
     },
     {
+      disk_name    = "disk-2"
       disk_size_gb = 10
       disk_type    = "pd-standard"
       auto_delete  = "true"

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -124,6 +124,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/examples/umig/full/variables.tf
+++ b/examples/umig/full/variables.tf
@@ -124,6 +124,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -16,7 +16,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | `string` | `"true"` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -95,6 +95,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number

--- a/modules/preemptible_and_regular_instance_templates/README.md
+++ b/modules/preemptible_and_regular_instance_templates/README.md
@@ -13,7 +13,7 @@ See the [simple](../../examples/preemptible_and_regular_instance_templates/simpl
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | `bool` | `true` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |

--- a/modules/preemptible_and_regular_instance_templates/variables.tf
+++ b/modules/preemptible_and_regular_instance_templates/variables.tf
@@ -83,6 +83,7 @@ variable "auto_delete" {
 variable "additional_disks" {
   description = "List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name"
   type = list(object({
+    disk_name    = string
     auto_delete  = bool
     boot         = bool
     disk_size_gb = number


### PR DESCRIPTION
Use disk_name for additional disks.

1. Persistent disks are not deleted when an instance is recreated, hence you can end up with stale persistent disks named after the instances that preceded it.
2. Allow to refer to the disks in other TF code, ie. when applying a snapshot policy.