### PR TITLE
Add confidential compute flags

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -19,6 +19,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
@@ -26,6 +27,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | name\_prefix | Name prefix for the instance template | `string` | `"default-instance-template"` | no |
 | network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
 | network\_ip | Private IP address to assign to the instance if desired. | `string` | `""` | no |
+| on\_host\_maintenance | Instance availability Policy | `string` | `"MIGRATE"` | no |
 | preemptible | Allow the instance to be preempted | `bool` | `false` | no |
 | project\_id | The GCP project ID | `string` | `null` | no |
 | region | Region where the instance template should be created. | `string` | `null` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -54,7 +54,7 @@ locals {
   on_host_maintenance = (
     var.preemptible || var.enable_confidential_vm
     ? "TERMINATE"
-    : "MIGRATE"
+    : var.on_host_maintenance
   )
 }
 
@@ -136,10 +136,7 @@ resource "google_compute_instance_template" "tpl" {
     }
   }
 
-  dynamic "confidential_instance_config" {
-    for_each = local.confidential_instance_config
-    content {
-      enable_confidential_compute = lookup(var.confidential_instance_config, "enable_confidential_compute", confidential_instance_config.value)
-    }
+  confidential_instance_config {
+      enable_confidential_compute = var.enable_confidential_vm
   }
 }

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -137,6 +137,6 @@ resource "google_compute_instance_template" "tpl" {
   }
 
   confidential_instance_config {
-      enable_confidential_compute = var.enable_confidential_vm
+    enable_confidential_compute = var.enable_confidential_vm
   }
 }

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -46,7 +46,7 @@ locals {
 
   # NOTE: Even if all the shielded_instance_config or confidential_instance_config
   # values are false, if the config block exists and an unsupported image is chosen,
-  # the apply will fail so we use a single-value array with the default value to 
+  # the apply will fail so we use a single-value array with the default value to
   # initialize the block only if it is enabled.
   shielded_vm_configs = var.enable_shielded_vm ? [true] : []
   confidential_instance_config = var.enable_confidential_vm ? [true] : []
@@ -55,7 +55,7 @@ locals {
     var.preemptible || var.enable_confidential_vm
     ? "TERMINATE"
     : "MIGRATE"
-  ) 
+  )
 }
 
 ####################
@@ -141,5 +141,5 @@ resource "google_compute_instance_template" "tpl" {
     content {
       enable_confidential_compute = lookup(var.confidential_instance_config, "enable_confidential_compute", confidential_instance_config.value)
     }
-  }  
+  }
 }

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -48,7 +48,7 @@ locals {
   # values are false, if the config block exists and an unsupported image is chosen,
   # the apply will fail so we use a single-value array with the default value to
   # initialize the block only if it is enabled.
-  shielded_vm_configs = var.enable_shielded_vm ? [true] : []
+  shielded_vm_configs          = var.enable_shielded_vm ? [true] : []
   confidential_instance_config = var.enable_confidential_vm ? [true] : []
 
   on_host_maintenance = (
@@ -122,8 +122,8 @@ resource "google_compute_instance_template" "tpl" {
 
   # scheduling must have automatic_restart be false when preemptible is true.
   scheduling {
-    preemptible       = var.preemptible
-    automatic_restart = ! var.preemptible
+    preemptible         = var.preemptible
+    automatic_restart   = ! var.preemptible
     on_host_maintenance = local.on_host_maintenance
   }
 

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -182,7 +182,7 @@ variable "enable_confidential_vm" {
 variable "confidential_instance_config" {
   description = "Not used unless enable_confidential_vm is true. Confidential VM configuration for the instance."
   type = object({
-    enable_confidential_compute  = bool
+    enable_confidential_compute = bool
   })
 
   default = {

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -172,6 +172,25 @@ variable "shielded_instance_config" {
 }
 
 ###########################
+# Confidential Compute VMs
+###########################
+variable "enable_confidential_vm" {
+  default     = false
+  description = "Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images"
+}
+
+variable "confidential_instance_config" {
+  description = "Not used unless enable_confidential_vm is true. Confidential VM configuration for the instance."
+  type = object({
+    enable_confidential_compute  = bool
+  })
+
+  default = {
+    enable_confidential_compute = true
+  }
+}
+
+###########################
 # Public IP
 ###########################
 variable "access_config" {

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -53,6 +53,12 @@ variable "preemptible" {
   default     = false
 }
 
+variable "on_host_maintenance" {
+  type        = string
+  description = "Instance availability Policy"
+  default     = "MIGRATE"
+}
+
 variable "region" {
   type        = string
   description = "Region where the instance template should be created."
@@ -177,17 +183,6 @@ variable "shielded_instance_config" {
 variable "enable_confidential_vm" {
   default     = false
   description = "Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images"
-}
-
-variable "confidential_instance_config" {
-  description = "Not used unless enable_confidential_vm is true. Confidential VM configuration for the instance."
-  type = object({
-    enable_confidential_compute = bool
-  })
-
-  default = {
-    enable_confidential_compute = true
-  }
 }
 
 ###########################


### PR DESCRIPTION
Fixes https://github.com/terraform-google-modules/terraform-google-vm/issues/130


Add support for conf. compute instances.  

Currently the conf compute flags are in googe-beta and i've tested it locally by overriding the provider block in the template defnition:
- modules/instance_template/main.tf`

```hcl
resource "google_compute_instance_template" "tpl" {
  provider = google-beta
  name_prefix             = "${var.name_prefix}-"
  project                 = var.project_id
```

---

with the config:

- `https://github.com/terraform-google-modules/terraform-google-vm/blob/master/examples/compute_instance/simple/main.tf`

```hcl
provider "google" {}

module "instance_template" {
  source          = "../../../modules/instance_template"
  region          = var.region
  project_id      = var.project_id
  subnetwork      = var.subnetwork
  service_account = var.service_account
  enable_confidential_vm = true
  source_image_project = "confidential-vm-images"
  source_image_family = "ubuntu-1804-lts"
  source_image = "ubuntu-1804-bionic-v20201014"
  machine_type = "n2d-standard-2"
}

module "compute_instance" {
  source            = "../../../modules/compute_instance"
  region            = var.region
  subnetwork        = var.subnetwork
  num_instances     = var.num_instances
  hostname          = "instance-simple"
  instance_template = module.instance_template.self_link
  access_config = [{
    nat_ip       = var.nat_ip
    network_tier = var.network_tier
  }, ]
}

```

- `https://github.com/terraform-google-modules/terraform-google-vm/blob/master/examples/compute_instance/simple/variables.tf`

```hcl
variable "project_id" {
  description = "The GCP project to use for integration tests"
  type        = string
  default = "mineral-minutia-820"
}

variable "region" {
  description = "The GCP region to create and test resources in"
  type        = string
  default     = "us-central1"
}

variable "subnetwork" {
  description = "The subnetwork selflink to host the compute instances in"
  default = "projects/mineral-minutia-820/regions/us-central1/subnetworks/default"
}

variable "num_instances" {
  description = "Number of instances to create"
}

variable "nat_ip" {
  description = "Public ip address"
  default     = null
}

variable "network_tier" {
  description = "Network network_tier"
  default     = "PREMIUM"
}


variable "service_account" {
  default = {
    email = "gce-svc-account@mineral-minutia-820.iam.gserviceaccount.com"
    scopes = ["cloud-platform"]
  }
  type = object({
    email  = string,
    scopes = set(string)
  })
  description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account."
}
```