### PR TITLE
feat: Allow Overriding MIG name (terraform-google-modules#87)

### DIFF
--- a/autogen/main.tf.tmpl
+++ b/autogen/main.tf.tmpl
@@ -59,7 +59,7 @@ resource "google_compute_region_instance_group_manager" "{{ module_name }}" {
   }
   {% endif %}
 
-  name   = "${var.hostname}-{{ module_name_hr }}"
+  name   = var.mig_name == "default" ? "${var.hostname}-{{ module_name_hr }}" : var.mig_name
   region = var.region
   dynamic "named_port" {
     for_each = var.named_ports

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -27,6 +27,11 @@ variable "hostname" {
   default     = "default"
 }
 
+variable "mig_name" {
+  description = "Managed instance group name"
+  default     = "default"
+}
+
 variable "region" {
   description = "The GCP region where the managed instance group resides."
 }

--- a/autogen/variables.tf.tmpl
+++ b/autogen/variables.tf.tmpl
@@ -28,7 +28,7 @@ variable "hostname" {
 }
 
 variable "mig_name" {
-  description = "Managed instance group name"
+  description = "Managed instance group name. When set to `default`, name will be derived from var.hostname."
   default     = "default"
 }
 

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -28,7 +28,7 @@ The current version is 2.X. The following guides are available to assist with up
 | hostname | Hostname prefix for instances | `string` | `"default"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
-| mig\_name | Managed instance group name | `string` | `"default"` | no |
+| mig\_name | Managed instance group name. When set to `default`, name will be derived from var.hostname. | `string` | `"default"` | no |
 | mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |

--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -28,6 +28,7 @@ The current version is 2.X. The following guides are available to assist with up
 | hostname | Hostname prefix for instances | `string` | `"default"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_name | Managed instance group name | `string` | `"default"` | no |
 | mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |

--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -43,7 +43,7 @@ resource "google_compute_region_instance_group_manager" "mig" {
     instance_template = var.instance_template
   }
 
-  name   = "${var.hostname}-mig"
+  name   = var.mig_name == "default" ? "${var.hostname}-mig" : var.mig_name
   region = var.region
   dynamic "named_port" {
     for_each = var.named_ports

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -27,6 +27,11 @@ variable "hostname" {
   default     = "default"
 }
 
+variable "mig_name" {
+  description = "Managed instance group name"
+  default     = "default"
+}
+
 variable "region" {
   description = "The GCP region where the managed instance group resides."
 }

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -28,7 +28,7 @@ variable "hostname" {
 }
 
 variable "mig_name" {
-  description = "Managed instance group name"
+  description = "Managed instance group name. When set to `default`, name will be derived from var.hostname."
   default     = "default"
 }
 

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -28,6 +28,7 @@ The current version is 2.X. The following guides are available to assist with up
 | instance\_template\_initial\_version | Instance template self\_link used to create compute instances for the initial version | `any` | n/a | yes |
 | instance\_template\_next\_version | Instance template self\_link used to create compute instances for the second version | `any` | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
+| mig\_name | Managed instance group name | `string` | `"default"` | no |
 | mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |

--- a/modules/mig_with_percent/README.md
+++ b/modules/mig_with_percent/README.md
@@ -28,7 +28,7 @@ The current version is 2.X. The following guides are available to assist with up
 | instance\_template\_initial\_version | Instance template self\_link used to create compute instances for the initial version | `any` | n/a | yes |
 | instance\_template\_next\_version | Instance template self\_link used to create compute instances for the second version | `any` | n/a | yes |
 | max\_replicas | The maximum number of instances that the autoscaler can scale up to. This is required when creating or updating an autoscaler. The maximum number of replicas should not be lower than minimal number of replicas. | `number` | `10` | no |
-| mig\_name | Managed instance group name | `string` | `"default"` | no |
+| mig\_name | Managed instance group name. When set to `default`, name will be derived from var.hostname. | `string` | `"default"` | no |
 | mig\_timeouts | Times for creation, deleting and updating the MIG resources. Can be helpful when using wait\_for\_instances to allow a longer VM startup time. | <pre>object({<br>    create = string<br>    update = string<br>    delete = string<br>  })</pre> | <pre>{<br>  "create": "5m",<br>  "delete": "15m",<br>  "update": "5m"<br>}</pre> | no |
 | min\_replicas | The minimum number of replicas that the autoscaler can scale down to. This cannot be less than 0. | `number` | `2` | no |
 | named\_ports | Named name and named port. https://cloud.google.com/load-balancing/docs/backend-service#named_ports | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |

--- a/modules/mig_with_percent/main.tf
+++ b/modules/mig_with_percent/main.tf
@@ -52,7 +52,7 @@ resource "google_compute_region_instance_group_manager" "mig_with_percent" {
     }
   }
 
-  name   = "${var.hostname}-mig-with-percent"
+  name   = var.mig_name == "default" ? "${var.hostname}-mig-with-percent" : var.mig_name
   region = var.region
   dynamic "named_port" {
     for_each = var.named_ports

--- a/modules/mig_with_percent/variables.tf
+++ b/modules/mig_with_percent/variables.tf
@@ -27,6 +27,11 @@ variable "hostname" {
   default     = "default"
 }
 
+variable "mig_name" {
+  description = "Managed instance group name"
+  default     = "default"
+}
+
 variable "region" {
   description = "The GCP region where the managed instance group resides."
 }

--- a/modules/mig_with_percent/variables.tf
+++ b/modules/mig_with_percent/variables.tf
@@ -28,7 +28,7 @@ variable "hostname" {
 }
 
 variable "mig_name" {
-  description = "Managed instance group name"
+  description = "Managed instance group name. When set to `default`, name will be derived from var.hostname."
   default     = "default"
 }
 


### PR DESCRIPTION
This allows for overriding the mig name which allows for multiple migs with the same hostname. And also allows for the use case of #87 Where they want the instances to have a different name than the mig.

Fixes #87 

Signed-off-by: Taylor Jones <taylor@tjon.es>