### PR TITLE
Change GCE image project as "gce-uefi-images" is being deprecated.

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -33,7 +33,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | shielded\_instance\_config | Not used unless enable\_shielded\_vm is true. Shielded VM configuration for the instance. | <pre>object({<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>    enable_integrity_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
 | source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `"centos-7"` | no |
-| source\_image\_project | Project where the source image comes from. The default project contains images that support Shielded VMs if desired | `string` | `"gce-uefi-images"` | no |
+| source\_image\_project | Project where the source image comes from. The default project contains CentOS images. | `string` | `"centos-cloud"` | no |
 | startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
 | subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
 | subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -73,8 +73,8 @@ variable "source_image_family" {
 }
 
 variable "source_image_project" {
-  description = "Project where the source image comes from. The default project contains images that support Shielded VMs if desired"
-  default     = "gce-uefi-images"
+  description = "Project where the source image comes from. The default project contains CentOS images."
+  default     = "centos-cloud"
 }
 
 variable "disk_size_gb" {

--- a/modules/mig/versions.tf
+++ b/modules/mig/versions.tf
@@ -21,9 +21,9 @@ terraform {
     google-beta = ">= 3.43, <4.0"
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.1.0"
+    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.0.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.1.0"
+    module_name = "blueprints/terraform/terraform-google-vm:mig/v6.0.0"
   }
 }

--- a/modules/mig_with_percent/versions.tf
+++ b/modules/mig_with_percent/versions.tf
@@ -21,9 +21,9 @@ terraform {
     google-beta = ">= 3.43, <4.0"
   }
   provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.1.0"
+    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.0.0"
   }
   provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.1.0"
+    module_name = "blueprints/terraform/terraform-google-vm:mig_with_percent/v6.0.0"
   }
 }


### PR DESCRIPTION
"gce-uefi-images" is being deprecated (ubuntu image has been removed from the project). As Shielded VM is by default now, users can just use images from their default prod image project.

sudo make build
sudo make docker_test_lint