### PR TITLE
Add support for local-ssd disks

### DIFF
--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -71,13 +71,13 @@ resource "google_compute_instance_template" "tpl" {
       boot         = lookup(disk.value, "boot", null)
       device_name  = lookup(disk.value, "device_name", null)
       disk_name    = lookup(disk.value, "disk_name", null)
-      disk_size_gb = lookup(disk.value, "disk_size_gb", null)
+      disk_size_gb = lookup(disk.value, "disk_size_gb", lookup(disk.value, "disk_type", null) == "local-ssd" ? "375" : null)
       disk_type    = lookup(disk.value, "disk_type", null)
-      interface    = lookup(disk.value, "interface", null)
+      interface    = lookup(disk.value, "interface", lookup(disk.value, "disk_type", null) == "local-ssd" ? "NVME" : null)
       mode         = lookup(disk.value, "mode", null)
       source       = lookup(disk.value, "source", null)
       source_image = lookup(disk.value, "source_image", null)
-      type         = lookup(disk.value, "type", null)
+      type         = lookup(disk.value, "disk_type", null) == "local-ssd" ? "SCRATCH" : "PERSISTENT"
 
       dynamic "disk_encryption_key" {
         for_each = lookup(disk.value, "disk_encryption_key", [])


### PR DESCRIPTION
This should solve the need for `local-ssd` disk types.

I tested it with:

```
  additional_disks = [
    {
      disk_name = ""
      device_name = ""
      auto_delete = "true"
      boot = "false"
      disk_type = "local-ssd"
      disk_size_gb = "375"
    },
    {
      disk_name = ""
      device_name = ""
      auto_delete = "true"
      boot = "false"
      disk_type = "local-ssd"
      disk_size_gb = "375"
    }
  ]
```

I saw other approaches in #138 #75 and based on those I tried this approach which considers:

- It will not be a breaking change.
- It fixes some settings like `disk_size_gb=375Gb` and `type=SCRATCH` but those can't be changed anyway when working with `local-ssd` disks (AFAIK).
- The only caveat I can think about is that the disk `interface` will be fixed for all the `local-ssd` disks you define (Instead of a per disk) but I think it is somewhat acceptable (At least in my use case).

Open to comments and feedback.

Thank you!

