### PR TITLE
Add support for guest_accelerator for the instance_template module

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -21,6 +21,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
+| gpu | GPU information. Type and count of GPU to attach to the instance template | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | n/a | yes |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | metadata | Metadata, provided as a map | `map(string)` | `{}` | no |

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -21,6 +21,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
+| gpu | GPU to attach to the instance. See https://cloud.google.com/compute/docs/gpus. | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | n/a | no |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | metadata | Metadata, provided as a map | `map(string)` | `{}` | no |

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -21,7 +21,6 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
-| gpu | GPU to attach to the instance. See https://cloud.google.com/compute/docs/gpus. | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | n/a | no |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | metadata | Metadata, provided as a map | `map(string)` | `{}` | no |

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -21,7 +21,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
-| gpu | GPU information. Type and count of GPU to attach to the instance template | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | n/a | yes |
+| gpu | GPU information. Type and count of GPU to attach to the instance template. See https://cloud.google.com/compute/docs/gpus more details | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | `null` | no |
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | metadata | Metadata, provided as a map | `map(string)` | `{}` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -51,8 +51,9 @@ locals {
   shielded_vm_configs          = var.enable_shielded_vm ? [true] : []
   confidential_instance_config = var.enable_confidential_vm ? [true] : []
 
+  gpu_enabled = var.gpu != ""
   on_host_maintenance = (
-    var.preemptible || var.enable_confidential_vm
+    var.preemptible || var.enable_confidential_vm || local.gpu_enabled
     ? "TERMINATE"
     : var.on_host_maintenance
   )
@@ -124,7 +125,7 @@ resource "google_compute_instance_template" "tpl" {
   # scheduling must have automatic_restart be false when preemptible is true.
   scheduling {
     preemptible         = var.preemptible
-    automatic_restart   = ! var.preemptible
+    automatic_restart   = !var.preemptible
     on_host_maintenance = local.on_host_maintenance
   }
 
@@ -139,5 +140,10 @@ resource "google_compute_instance_template" "tpl" {
 
   confidential_instance_config {
     enable_confidential_compute = var.enable_confidential_vm
+  }
+
+  guest_accelerator {
+    type  = var.gpu.type
+    count = var.gpu.count
   }
 }

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -143,7 +143,7 @@ resource "google_compute_instance_template" "tpl" {
   }
 
   dynamic "guest_accelerator" {
-    for_each = local.gpu_enabled ? list(var.gpu) : []
+    for_each = local.gpu_enabled ? [var.gpu] : []
     content {
       type  = guest_accelerator.value.type
       count = guest_accelerator.value.count

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -203,3 +203,14 @@ variable "access_config" {
   }))
   default = []
 }
+
+###########################
+# Guest Accelerator (GPU)
+###########################
+variable "gpu" {
+  description = "GPU "
+  type = object({
+    type  = string
+    count = number
+  })
+}

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -208,9 +208,10 @@ variable "access_config" {
 # Guest Accelerator (GPU)
 ###########################
 variable "gpu" {
-  description = "GPU information. Type and count of GPU to attach to the instance template"
+  description = "GPU information. Type and count of GPU to attach to the instance template. See https://cloud.google.com/compute/docs/gpus more details"
   type = object({
     type  = string
     count = number
   })
+  default = null
 }

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -208,7 +208,7 @@ variable "access_config" {
 # Guest Accelerator (GPU)
 ###########################
 variable "gpu" {
-  description = "GPU "
+  description = "GPU information. Type and count of GPU to attach to the instance template"
   type = object({
     type  = string
     count = number


### PR DESCRIPTION
## Issue
- Current `inputs` for the `instance_template` module does not support associating a GPU to the template; however this is supported in the [`google_compute_instance_template`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#guest_accelerator) used by the module itself.

## Fix
- Add support for associating a GPU to the template by adding a new input variable `gpu` to module.
- We internally use the already existing `guest_accelerator` variable of `google_compute_instance_template` 

## Related issues
- PR opened in part to support the effort to enable AnthosBM installation using Terraform [(PR#11 of Anthos Samples)](https://github.com/GoogleCloudPlatform/anthos-samples/pull/11)
- Related [issue](https://github.com/GoogleCloudPlatform/anthos-samples/issues/12) on the same repo