### PR TITLE
feat: Add support for min_cpu_platform variable

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -24,6 +24,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | labels | Labels, provided as a map | `map(string)` | `{}` | no |
 | machine\_type | Machine type to create, e.g. n1-standard-1 | `string` | `"n1-standard-1"` | no |
 | metadata | Metadata, provided as a map | `map(string)` | `{}` | no |
+| min\_cpu\_platform | Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list: https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform | `string` | `null` | no |
 | name\_prefix | Name prefix for the instance template | `string` | `"default-instance-template"` | no |
 | network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
 | network\_ip | Private IP address to assign to the instance if desired. | `string` | `""` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -71,6 +71,7 @@ resource "google_compute_instance_template" "tpl" {
   can_ip_forward          = var.can_ip_forward
   metadata_startup_script = var.startup_script
   region                  = var.region
+  min_cpu_platform        = var.min_cpu_platform
   dynamic "disk" {
     for_each = local.all_disks
     content {

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -30,6 +30,12 @@ variable "machine_type" {
   default     = "n1-standard-1"
 }
 
+variable "min_cpu_platform" {
+  description = "Specifies a minimum CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell or Intel Skylake. See the complete list: https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform"
+  type        = string
+  default     = null
+}
+
 variable "can_ip_forward" {
   description = "Enable IP forwarding, for NAT instances for example"
   default     = "false"


### PR DESCRIPTION
## Issue
- Current `inputs` for the `instance_template` module does not support the `min_cpu_platform` attribute; however this is supported in the [`google_compute_instance_template`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#min_cpu_platform) used by the module itself.

## Fix
- Add support for `min_cpu_platform`.

## Related issues/PRs
-  Noticed this stale [PR#102](https://github.com/terraform-google-modules/terraform-google-vm/pull/102) opened some ago; both do the same thing
- PR opened in part to support the effort to enable AnthosBM installation using Terraform [(PR#11 of Anthos Samples)](https://github.com/GoogleCloudPlatform/anthos-samples/pull/11)