### PR TITLE
Adds labels to boot and additional disks

### DIFF
--- a/examples/compute_instance/disk_snapshot/main.tf
+++ b/examples/compute_instance/disk_snapshot/main.tf
@@ -44,6 +44,7 @@ module "instance_template" {
       disk_type    = "pd-standard"
       disk_name    = null
       device_name  = null
+      disk_labels  = { "foo" : "bar" }
     },
     {
       auto_delete  = true
@@ -52,6 +53,7 @@ module "instance_template" {
       disk_type    = "pd-standard"
       disk_name    = null
       device_name  = null
+      disk_labels  = {}
     }
   ]
 }

--- a/examples/instance_template/additional_disks/main.tf
+++ b/examples/instance_template/additional_disks/main.tf
@@ -36,6 +36,7 @@ module "instance_template" {
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
+      disk_labels  = {}
     },
     {
       disk_name    = "disk-1"
@@ -44,6 +45,7 @@ module "instance_template" {
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
+      disk_labels  = { "foo" : "bar" }
     },
     {
       disk_name    = "disk-2"
@@ -52,6 +54,7 @@ module "instance_template" {
       disk_type    = "pd-standard"
       auto_delete  = "true"
       boot         = "false"
+      disk_labels  = { "foo" : "bar" }
     },
   ]
 }

--- a/examples/mig/full/main.tf
+++ b/examples/mig/full/main.tf
@@ -53,6 +53,7 @@ module "instance_template" {
   /* disks */
   disk_size_gb     = var.disk_size_gb
   disk_type        = var.disk_type
+  disk_labels      = var.disk_labels
   auto_delete      = var.auto_delete
   additional_disks = var.additional_disks
 }

--- a/examples/mig/full/variables.tf
+++ b/examples/mig/full/variables.tf
@@ -116,6 +116,11 @@ variable "disk_type" {
   default     = "pd-standard"
 }
 
+variable "disk_labels" {
+  description = "Labels to be assigned to boot disk, provided as a map"
+  default     = { "foo" : "bar" }
+}
+
 variable "auto_delete" {
   description = "Whether or not the disk should be auto-deleted"
   default     = "true"
@@ -130,6 +135,7 @@ variable "additional_disks" {
     boot         = bool
     disk_size_gb = number
     disk_type    = string
+    disk_labels  = map(string)
   }))
   default = []
 }

--- a/examples/umig/full/variables.tf
+++ b/examples/umig/full/variables.tf
@@ -130,6 +130,7 @@ variable "additional_disks" {
     boot         = bool
     disk_size_gb = number
     disk_type    = string
+    disk_labels  = map(string)
   }))
   default = []
 }

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -14,12 +14,12 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>  }))</pre> | `[]` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | `string` | `"true"` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
+| disk\_labels | Labels to be assigned to boot disk, provided as a map | `map(string)` | `{}` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
-| disk\_labels | Boot disk labels, provided as a map | `map(string)` | `{}` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | gpu | GPU information. Type and count of GPU to attach to the instance template. See https://cloud.google.com/compute/docs/gpus more details | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | `null` | no |

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -19,6 +19,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
+| disk\_labels | Boot disk labels, provided as a map | `map(string)` | `{}` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | enable\_shielded\_vm | Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |
 | gpu | GPU information. Type and count of GPU to attach to the instance template. See https://cloud.google.com/compute/docs/gpus more details | <pre>object({<br>    type  = string<br>    count = number<br>  })</pre> | `null` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -128,7 +128,7 @@ resource "google_compute_instance_template" "tpl" {
   # scheduling must have automatic_restart be false when preemptible is true.
   scheduling {
     preemptible         = var.preemptible
-    automatic_restart   = !var.preemptible
+    automatic_restart   = ! var.preemptible
     on_host_maintenance = local.on_host_maintenance
   }
 

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -37,6 +37,7 @@ locals {
       source_image = var.source_image != "" ? data.google_compute_image.image.self_link : data.google_compute_image.image_family.self_link
       disk_size_gb = var.disk_size_gb
       disk_type    = var.disk_type
+      disk_labels  = var.disk_labels
       auto_delete  = var.auto_delete
       boot         = "true"
     },
@@ -87,6 +88,7 @@ resource "google_compute_instance_template" "tpl" {
       source       = lookup(disk.value, "source", null)
       source_image = lookup(disk.value, "source_image", null)
       type         = lookup(disk.value, "disk_type", null) == "local-ssd" ? "SCRATCH" : "PERSISTENT"
+      labels       = lookup(disk.value, "disk_labels", null)
 
       dynamic "disk_encryption_key" {
         for_each = lookup(disk.value, "disk_encryption_key", [])
@@ -126,7 +128,7 @@ resource "google_compute_instance_template" "tpl" {
   # scheduling must have automatic_restart be false when preemptible is true.
   scheduling {
     preemptible         = var.preemptible
-    automatic_restart   = ! var.preemptible
+    automatic_restart   = !var.preemptible
     on_host_maintenance = local.on_host_maintenance
   }
 

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -99,6 +99,12 @@ variable "disk_type" {
   default     = "pd-standard"
 }
 
+variable "disk_labels" {
+  description = "Labels to be assigned to boot disk, provided as a map"
+  type        = map(string)
+  default     = {}
+}
+
 variable "auto_delete" {
   description = "Whether or not the boot disk should be auto-deleted"
   default     = "true"
@@ -113,6 +119,7 @@ variable "additional_disks" {
     boot         = bool
     disk_size_gb = number
     disk_type    = string
+    disk_labels  = map(string)
   }))
   default = []
 }

--- a/modules/preemptible_and_regular_instance_templates/README.md
+++ b/modules/preemptible_and_regular_instance_templates/README.md
@@ -13,7 +13,7 @@ See the [simple](../../examples/preemptible_and_regular_instance_templates/simpl
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
-| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>  }))</pre> | `[]` | no |
+| additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>  }))</pre> | `[]` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | `bool` | `true` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |

--- a/modules/preemptible_and_regular_instance_templates/variables.tf
+++ b/modules/preemptible_and_regular_instance_templates/variables.tf
@@ -89,6 +89,7 @@ variable "additional_disks" {
     boot         = bool
     disk_size_gb = number
     disk_type    = string
+    disk_labels  = map(string)
   }))
   default = []
 }


### PR DESCRIPTION
Disk attached to instances created to a template does not assign labels to it. This changes allow labels to be set to boot and additional disks of instance templates.

This PR might fix #167 