### PR TITLE
Fix(compute_instance): updating access_config to 2d array to allow multiple IPs

### DIFF
--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -20,6 +20,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |
+| override\_hostname | Override the generated hostname | `string` | `""` | no |
 | region | Region where the instances should be created. | `string` | `null` | no |
 | static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -41,7 +41,7 @@ data "google_compute_zones" "available" {
 resource "google_compute_instance_from_template" "compute_instance" {
   provider = google
   count    = local.num_instances
-  name     = "${local.hostname}-${format("%03d", count.index + 1)}"
+  name     = var.override_hostname ? var.override_hostname : "${local.hostname}-${format("%03d", count.index + 1)}"
   project  = local.project_id
   zone     = var.zone == null ? data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)] : var.zone
 

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -34,6 +34,12 @@ variable "hostname" {
   default     = ""
 }
 
+variable "override_hostname" {
+  type        = string
+  description = "Override the generated hostname"
+  default     = ""
+}
+
 variable "static_ips" {
   type        = list(string)
   description = "List of static IPs for VM instances"


### PR DESCRIPTION
Porting over fix from `umig` https://github.com/terraform-google-modules/terraform-google-vm/pull/111 

Problem:

Currently it is not possible to have multiple instances with predefined access configs (external ips). If one would want to create 3 instances with 3 external ips, each instance would get same 3 predefined external ips. Which is not possible.

The way it is configured right now it tries to set multiple access_configs on 1 instance/interface, which is incorrect.

```
      + network_interface {
          + access_config      = [
              + {
                  + nat_ip                 = "x.x.x.x"
                  + network_tier           = "PREMIUM"
                  + public_ptr_domain_name = (known after apply)
                },
              + {
                  + nat_ip                 = "x.x.x.x"
                  + network_tier           = "PREMIUM"
                  + public_ptr_domain_name = (known after apply)
                },
```
Solution:

Make access_config 2D array, so each instance would get an array of predefined ips.