### PR TITLE
fix: revert change related to sensitive field bug in terraform 0.15.0

### DIFF
--- a/modules/compute_instance/outputs.tf
+++ b/modules/compute_instance/outputs.tf
@@ -22,7 +22,6 @@ output "instances_self_links" {
 output "instances_details" {
   description = "List of all details for compute instances"
   value       = google_compute_instance_from_template.compute_instance.*
-  sensitive   = true
 }
 
 output "available_zones" {


### PR DESCRIPTION
### Description

- This PR reverts the change in PR #164 
- That PR was opened in response to issue #163 
- Issue #163 was due to bugs specific to changes on `sensitive` flag in terraform `v15.0.0` 
    - https://github.com/hashicorp/terraform/pull/28442
    - https://github.com/hashicorp/terraform/pull/28383
    - https://github.com/hashicorp/terraform/pull/28472
- All these bugs were fixed in terraform `v0.15.0.1` - [Release notes](https://github.com/hashicorp/terraform/releases/tag/v0.15.1)

- Having this field as **sensitive** prevents using the attributes of the `instance_details` output in any other terraform script. (e.g: [anthos-samples use case](https://github.com/GoogleCloudPlatform/anthos-samples/blob/master/anthos-bm-gcp-terraform/modules/vm/outputs.tf#L21))
- The originally reported issue is evaded since `~> v0.15.1` and the `sensitive = true` workaround is not needed