### PR TITLE
Update network.tf

### DIFF
--- a/test/fixtures/shared/network.tf
+++ b/test/fixtures/shared/network.tf
@@ -33,7 +33,7 @@ resource "google_compute_network" "main" {
 resource "google_compute_subnetwork" "main" {
   project       = var.project_id
   region        = "us-central1"
-  name          = "cft-vm-test-${random_string.suffix.result}"
+  name          = "cft-vm-test-subnet-${random_string.suffix.result}"
   ip_cidr_range = "10.128.0.0/20"
-  network       = google_compute_network.main.self_link
+  network       = google_compute_network.main.id
 }


### PR DESCRIPTION
add subnet to subnet's name
switch from selflink to .id as described in example here "Example Usage - Subnetwork Internal L7lb"
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_subnetwork