### PR TITLE
Add the ability to specify multiple NICs to VMs

### DIFF
--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -25,6 +25,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
+| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: `network`, `subnetwork`, `subnetwork_project`, `network_ip` and `access_config`. | `array(map(string))` | `[]` | no |
 | zone | Zone where the instances should be created. If not specified, instances will be spread across available zones in the region. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -17,6 +17,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | add\_hostname\_suffix | Adds a suffix to the hostname | `bool` | `true` | no |
+| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork\_project, network\_ip and access\_config. | `list` | `[]` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
@@ -25,7 +26,6 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
-| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: `network`, `subnetwork`, `subnetwork_project`, `network_ip` and `access_config`. | `array(map(string))` | `[]` | no |
 | zone | Zone where the instances should be created. If not specified, instances will be spread across available zones in the region. | `string` | `null` | no |
 
 ## Outputs

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -59,6 +59,23 @@ resource "google_compute_instance_from_template" "compute_instance" {
     }
   }
 
+  dynamic "network_interface" {
+    for_each = var.additional_networks
+    content {
+      network            = lookup(network_interface.value, "network", null)
+      subnetwork         = lookup(network_interface.value, "subnetwork", null)
+      subnetwork_project = lookup(network_interface.value, "subnetwork_project", null)
+      network_ip         = lookup(network_interface.value, "network_ip", null)
+      dynamic "access_config" {
+        for_each = lookup(network_interface.value, "access_config", [])
+        content {
+          nat_ip       = lookup(access_config.value, "nat_ip", [])
+          network_tier = lookup(access_config.value, "network_tier", [])
+        }
+      }
+    }
+  }
+
   source_instance_template = var.instance_template
 }
 

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -74,3 +74,9 @@ variable "zone" {
   description = "Zone where the instances should be created. If not specified, instances will be spread across available zones in the region."
   default     = null
 }
+
+# Additional NICs
+variable "additional_networks" {
+  description = "If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork_project, network_ip and access_config."
+  default     = []
+}

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -15,6 +15,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | additional\_disks | List of maps of additional disks. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#disk_name | <pre>list(object({<br>    disk_name    = string<br>    device_name  = string<br>    auto_delete  = bool<br>    boot         = bool<br>    disk_size_gb = number<br>    disk_type    = string<br>    disk_labels  = map(string)<br>  }))</pre> | `[]` | no |
+| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork\_project, network\_ip and access\_config. | `list` | `[]` | no |
 | auto\_delete | Whether or not the boot disk should be auto-deleted | `string` | `"true"` | no |
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_labels | Labels to be assigned to boot disk, provided as a map | `map(string)` | `{}` | no |
@@ -42,7 +43,6 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
 | subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
 | subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
-| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: `network`, `subnetwork`, `subnetwork_project`, `network_ip` and `access_config`. | `array(map(string))` | `[]` | no |
 | tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -42,6 +42,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | startup\_script | User startup script to run when instances spin up | `string` | `""` | no |
 | subnetwork | The name of the subnetwork to attach this interface to. The subnetwork must exist in the same region this instance will be created in. Either network or subnetwork must be provided. | `string` | `""` | no |
 | subnetwork\_project | The ID of the project in which the subnetwork belongs. If it is not provided, the provider project is used. | `string` | `""` | no |
+| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: `network`, `subnetwork`, `subnetwork_project`, `network_ip` and `access_config`. | `array(map(string))` | `[]` | no |
 | tags | Network tags, provided as a list | `list(string)` | `[]` | no |
 
 ## Outputs

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -124,15 +124,15 @@ resource "google_compute_instance_template" "tpl" {
   dynamic "network_interface" {
     for_each = var.additional_networks
     content {
-      network            = network_interface.value["network"]
-      subnetwork         = network_interface.value["subnetwork"]
-      subnetwork_project = network_interface.value["subnetwork_project"]
-      network_ip         = length(network_interface.value["network_ip"]) > 0 ? network_interface.value["network_ip"] : null
+      network            = lookup(network_interface.value, "network", null)
+      subnetwork         = lookup(network_interface.value, "subnetwork", null)
+      subnetwork_project = lookup(network_interface.value, "subnetwork_project", null)
+      network_ip         = length(lookup(network_interface.value, "network_ip", null)) > 0 ? network_interface.value["network_ip"] : null
       dynamic "access_config" {
-        for_each = network_interface.value["access_config"]
+        for_each = lookup(network_interface.value, "access_config", [])
         content {
-          nat_ip       = access_config.value.nat_ip
-          network_tier = access_config.value.network_tier
+          nat_ip       = lookup(access_config.value, "nat_ip", [])
+          network_tier = lookup(access_config.value, "network_tier", [])
         }
       }
     }

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -127,7 +127,7 @@ resource "google_compute_instance_template" "tpl" {
       network            = lookup(network_interface.value, "network", null)
       subnetwork         = lookup(network_interface.value, "subnetwork", null)
       subnetwork_project = lookup(network_interface.value, "subnetwork_project", null)
-      network_ip         = length(lookup(network_interface.value, "network_ip", null)) > 0 ? lookup(network_interface.value, "network_ip", null) : null
+      network_ip         = lookup(network_interface.value, "network_ip", null)
       dynamic "access_config" {
         for_each = lookup(network_interface.value, "access_config", [])
         content {

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -127,7 +127,7 @@ resource "google_compute_instance_template" "tpl" {
       network            = lookup(network_interface.value, "network", null)
       subnetwork         = lookup(network_interface.value, "subnetwork", null)
       subnetwork_project = lookup(network_interface.value, "subnetwork_project", null)
-      network_ip         = length(lookup(network_interface.value, "network_ip", null)) > 0 ? network_interface.value["network_ip"] : null
+      network_ip         = length(lookup(network_interface.value, "network_ip", null)) > 0 ? lookup(network_interface.value, "network_ip", null) : null
       dynamic "access_config" {
         for_each = lookup(network_interface.value, "access_config", [])
         content {

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -121,6 +121,23 @@ resource "google_compute_instance_template" "tpl" {
     }
   }
 
+  dynamic "network_interface" {
+    for_each = var.additional_networks
+    content {
+      network            = network_interface.value["network"]
+      subnetwork         = network_interface.value["subnetwork"]
+      subnetwork_project = network_interface.value["subnetwork_project"]
+      network_ip         = length(network_interface.value["network_ip"]) > 0 ? network_interface.value["network_ip"] : null
+      dynamic "access_config" {
+        for_each = network_interface.value["access_config"]
+        content {
+          nat_ip       = access_config.value.nat_ip
+          network_tier = access_config.value.network_tier
+        }
+      }
+    }
+  }
+
   lifecycle {
     create_before_destroy = "true"
   }

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -147,6 +147,12 @@ variable "network_ip" {
   default     = ""
 }
 
+# Additional NICs
+variable "additional_networks" {
+  description = "If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork_project, network_ip and access_config."
+  default     = []
+}
+
 ###########
 # metadata
 ###########

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -16,6 +16,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  })))</pre> | `[]` | no |
+| additional\_networks | If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork\_project, network\_ip and access\_config. | `list` | `[]` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -66,6 +66,23 @@ resource "google_compute_instance_from_template" "compute_instance" {
     }
   }
 
+  dynamic "network_interface" {
+    for_each = var.additional_networks
+    content {
+      network            = lookup(network_interface.value, "network", null)
+      subnetwork         = lookup(network_interface.value, "subnetwork", null)
+      subnetwork_project = lookup(network_interface.value, "subnetwork_project", null)
+      network_ip         = lookup(network_interface.value, "network_ip", null)
+      dynamic "access_config" {
+        for_each = lookup(network_interface.value, "access_config", [])
+        content {
+          nat_ip       = lookup(access_config.value, "nat_ip", [])
+          network_tier = lookup(access_config.value, "network_tier", [])
+        }
+      }
+    }
+  }
+
   source_instance_template = var.instance_template
 }
 

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -77,3 +77,9 @@ variable "access_config" {
   })))
   default = []
 }
+
+# Additional NICs
+variable "additional_networks" {
+  description = "If more than a one NIC is required for the instance, use this variable in addition to network-related variables. The format should be an array of objects with the same structure: network, subnetwork, subnetwork_project, network_ip and access_config."
+  default     = []
+}


### PR DESCRIPTION
For one of the projects, there was a requirement for instances to have multiple NICs for instances (they act like a proxy/fw for subnetworks). This PR adds such possibility for google vm modules via the new non-required argument.