### PR TITLE
Feat/suffix separator variable

### DIFF
--- a/examples/compute_instance/disk_snapshot/main.tf
+++ b/examples/compute_instance/disk_snapshot/main.tf
@@ -31,7 +31,7 @@ module "instance_template" {
   project_id      = var.project_id
   subnetwork      = var.subnetwork
   name_prefix     = "instance-disk-snapshot"
-  service_account = null
+  service_account = { email = "", scopes = ["cloud-platform"] }
 
   additional_disks = [
     {

--- a/examples/compute_instance/disk_snapshot/main.tf
+++ b/examples/compute_instance/disk_snapshot/main.tf
@@ -31,7 +31,7 @@ module "instance_template" {
   project_id      = var.project_id
   subnetwork      = var.subnetwork
   name_prefix     = "instance-disk-snapshot"
-  service_account = { email = "", scopes = ["cloud-platform"] }
+  service_account = null
 
   additional_disks = [
     {

--- a/examples/mig/healthcheck/main.tf
+++ b/examples/mig/healthcheck/main.tf
@@ -54,7 +54,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   project_id      = var.project_id
   subnetwork      = google_compute_subnetwork.main.name
-  service_account = { email = "", scopes = ["cloud-platform"] }
+  service_account = null
 }
 
 /** Instance Group within autoscale and health check **/

--- a/examples/mig/healthcheck/main.tf
+++ b/examples/mig/healthcheck/main.tf
@@ -64,9 +64,10 @@ module "mig" {
   project_id          = var.project_id
   instance_template   = module.instance_template.self_link
   region              = var.region
-  autoscaling_enabled = "true"
+  autoscaling_enabled = true
   min_replicas        = 2
   autoscaler_name     = "mig-as"
+  hostname            = "mig-as"
 
   autoscaling_cpu = [
     {

--- a/examples/mig/healthcheck/main.tf
+++ b/examples/mig/healthcheck/main.tf
@@ -54,7 +54,7 @@ module "instance_template" {
   source          = "../../../modules/instance_template"
   project_id      = var.project_id
   subnetwork      = google_compute_subnetwork.main.name
-  service_account = null
+  service_account = { email = "", scopes = ["cloud-platform"] }
 }
 
 /** Instance Group within autoscale and health check **/

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -18,6 +18,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | add\_hostname\_suffix | Adds a suffix to the hostname | `bool` | `true` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
+| hostname\_suffix\_separator | Separator charactere to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -18,7 +18,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | add\_hostname\_suffix | Adds a suffix to the hostname | `bool` | `true` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
-| hostname\_suffix\_separator | Separator charactere to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
+| hostname\_suffix\_separator | Separator character to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `string` | `"1"` | no |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -41,7 +41,7 @@ data "google_compute_zones" "available" {
 resource "google_compute_instance_from_template" "compute_instance" {
   provider = google
   count    = local.num_instances
-  name     = var.add_hostname_suffix ? "${local.hostname}-${format("%03d", count.index + 1)}" : local.hostname
+  name     = var.add_hostname_suffix ? format("%s%s%s", local.hostname, var.hostname_suffix_separator, format("%03d", count.index + 1)) : local.hostname
   project  = local.project_id
   zone     = var.zone == null ? data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)] : var.zone
 

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -77,6 +77,6 @@ variable "zone" {
 
 variable "hostname_suffix_separator" {
   type        = string
-  description = "Separator charactere to compose hostname when add_hostname_suffix is set to true."
+  description = "Separator character to compose hostname when add_hostname_suffix is set to true."
   default     = "-"
 }

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -74,3 +74,9 @@ variable "zone" {
   description = "Zone where the instances should be created. If not specified, instances will be spread across available zones in the region."
   default     = null
 }
+
+variable "hostname_suffix_separator" {
+  type        = string
+  description = "Separator charactere to compose hostname when add_hostname_suffix is set to true."
+  default     = "-"
+}

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -18,6 +18,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  })))</pre> | `[]` | no |
 | additional\_networks | Additional network interface details for GCE, if any. | <pre>list(object({<br>    network            = string<br>    subnetwork         = string<br>    subnetwork_project = string<br>    network_ip         = string<br>    access_config = list(object({<br>      nat_ip       = string<br>      network_tier = string<br>    }))<br>  }))</pre> | `[]` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
+| hostname\_suffix\_separator | Separator charactere to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -18,7 +18,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  })))</pre> | `[]` | no |
 | additional\_networks | Additional network interface details for GCE, if any. | <pre>list(object({<br>    network            = string<br>    subnetwork         = string<br>    subnetwork_project = string<br>    network_ip         = string<br>    access_config = list(object({<br>      nat_ip       = string<br>      network_tier = string<br>    }))<br>  }))</pre> | `[]` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
-| hostname\_suffix\_separator | Separator charactere to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
+| hostname\_suffix\_separator | Separator character to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |
 | named\_ports | Named name and named port | <pre>list(object({<br>    name = string<br>    port = number<br>  }))</pre> | `[]` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |

--- a/modules/umig/main.tf
+++ b/modules/umig/main.tf
@@ -46,7 +46,7 @@ data "google_compute_zones" "available" {
 resource "google_compute_instance_from_template" "compute_instance" {
   provider = google
   count    = local.num_instances
-  name     = "${local.hostname}-${format("%03d", count.index + 1)}"
+  name     = format("%s%s%s", local.hostname, var.hostname_suffix_separator, format("%03d", count.index + 1))
   project  = var.project_id
   zone     = data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)]
 

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -92,3 +92,9 @@ variable "access_config" {
   })))
   default = []
 }
+
+variable "hostname_suffix_separator" {
+  type        = string
+  description = "Separator charactere to compose hostname when add_hostname_suffix is set to true."
+  default     = "-"
+}

--- a/modules/umig/variables.tf
+++ b/modules/umig/variables.tf
@@ -95,6 +95,6 @@ variable "access_config" {
 
 variable "hostname_suffix_separator" {
   type        = string
-  description = "Separator charactere to compose hostname when add_hostname_suffix is set to true."
+  description = "Separator character to compose hostname when add_hostname_suffix is set to true."
   default     = "-"
 }

--- a/test/integration/mig_healthcheck/controls/mig_healthcheck.rb
+++ b/test/integration/mig_healthcheck/controls/mig_healthcheck.rb
@@ -134,7 +134,7 @@ control "MIG" do
 
     describe "https health check settings" do
       it "checkIntervalSec should be 5" do
-        expect(data[0]['healthyThreshold']).to eq(5)
+        expect(data[0]['checkIntervalSec']).to eq(5)
       end
     end
 


### PR DESCRIPTION
Add new variable to handle hostname separator char in the `compute_instance` and `umig` modules.
Discussed on issue https://github.com/terraform-google-modules/terraform-google-vm/issues/217