### PR TITLE
[compute_instance] Add deletion_protection variable

### DIFF
--- a/examples/compute_instance/simple/README.md
+++ b/examples/compute_instance/simple/README.md
@@ -7,6 +7,7 @@ This is a simple, minimal example of how to use the compute_instance module
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| deletion\_protection | Enable deletion protection on this instance. Note: you must disable deletion protection before removing the resource, or the instance cannot be deleted and the Terraform run will not complete successfully. | `bool` | `false` | no |
 | nat\_ip | Public ip address | `any` | `null` | no |
 | network\_tier | Network network\_tier | `string` | `"PREMIUM"` | no |
 | num\_instances | Number of instances to create | `any` | n/a | yes |

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -23,13 +23,15 @@ module "instance_template" {
 }
 
 module "compute_instance" {
-  source            = "../../../modules/compute_instance"
-  region            = var.region
-  zone              = var.zone
-  subnetwork        = var.subnetwork
-  num_instances     = var.num_instances
-  hostname          = "instance-simple"
-  instance_template = module.instance_template.self_link
+  source              = "../../../modules/compute_instance"
+  region              = var.region
+  zone                = var.zone
+  subnetwork          = var.subnetwork
+  num_instances       = var.num_instances
+  hostname            = "instance-simple"
+  instance_template   = module.instance_template.self_link
+  deletion_protection = false
+
   access_config = [{
     nat_ip       = var.nat_ip
     network_tier = var.network_tier

--- a/examples/compute_instance/simple/variables.tf
+++ b/examples/compute_instance/simple/variables.tf
@@ -51,6 +51,11 @@ variable "network_tier" {
   default     = "PREMIUM"
 }
 
+variable "deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection on this instance. Note: you must disable deletion protection before removing the resource, or the instance cannot be deleted and the Terraform run will not complete successfully."
+  default     = false
+}
 
 variable "service_account" {
   default = null

--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -17,6 +17,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 |------|-------------|------|---------|:--------:|
 | access\_config | Access configurations, i.e. IPs via which the VM instance can be accessed via the Internet. | <pre>list(object({<br>    nat_ip       = string<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | add\_hostname\_suffix | Adds a suffix to the hostname | `bool` | `true` | no |
+| deletion\_protection | Enable deletion protection on this instance. Note: you must disable deletion protection before removing the resource, or the instance cannot be deleted and the Terraform run will not complete successfully. | `bool` | `false` | no |
 | hostname | Hostname of instances | `string` | `""` | no |
 | hostname\_suffix\_separator | Separator character to compose hostname when add\_hostname\_suffix is set to true. | `string` | `"-"` | no |
 | instance\_template | Instance template self\_link used to create compute instances | `any` | n/a | yes |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -39,11 +39,13 @@ data "google_compute_zones" "available" {
 #############
 
 resource "google_compute_instance_from_template" "compute_instance" {
-  provider = google
-  count    = local.num_instances
-  name     = var.add_hostname_suffix ? format("%s%s%s", local.hostname, var.hostname_suffix_separator, format("%03d", count.index + 1)) : local.hostname
-  project  = local.project_id
-  zone     = var.zone == null ? data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)] : var.zone
+  provider            = google
+  count               = local.num_instances
+  name                = var.add_hostname_suffix ? format("%s%s%s", local.hostname, var.hostname_suffix_separator, format("%03d", count.index + 1)) : local.hostname
+  project             = local.project_id
+  zone                = var.zone == null ? data.google_compute_zones.available.names[count.index % length(data.google_compute_zones.available.names)] : var.zone
+  deletion_protection = var.deletion_protection
+
 
   network_interface {
     network            = var.network

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -80,3 +80,9 @@ variable "hostname_suffix_separator" {
   description = "Separator character to compose hostname when add_hostname_suffix is set to true."
   default     = "-"
 }
+
+variable "deletion_protection" {
+  type        = bool
+  description = "Enable deletion protection on this instance. Note: you must disable deletion protection before removing the resource, or the instance cannot be deleted and the Terraform run will not complete successfully."
+  default     = false
+}


### PR DESCRIPTION
This PR adds a new variable `deletion_protection` to the sub module `compute_instance`, which allows you to enable deletion protection on instances:

https://cloud.google.com/compute/docs/instances/preventing-accidental-vm-deletion
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance