### PR TITLE
Update README.md to fix broken link

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -38,7 +38,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | preemptible | Allow the instance to be preempted | `bool` | `false` | no |
 | project\_id | The GCP project ID | `string` | `null` | no |
 | region | Region where the instance template should be created. | `string` | `null` | no |
-| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template.html#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| service\_account | Service account to attach to the instance. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
 | shielded\_instance\_config | Not used unless enable\_shielded\_vm is true. Shielded VM configuration for the instance. | <pre>object({<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>    enable_integrity_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
 | source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `"centos-7"` | no |

--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -38,7 +38,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | preemptible | Allow the instance to be preempted | `bool` | `false` | no |
 | project\_id | The GCP project ID | `string` | `null` | no |
 | region | Region where the instance template should be created. | `string` | `null` | no |
-| service\_account | Service account to attach to the instance. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
+| service\_account | Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template#service_account. | <pre>object({<br>    email  = string<br>    scopes = set(string)<br>  })</pre> | n/a | yes |
 | shielded\_instance\_config | Not used unless enable\_shielded\_vm is true. Shielded VM configuration for the instance. | <pre>object({<br>    enable_secure_boot          = bool<br>    enable_vtpm                 = bool<br>    enable_integrity_monitoring = bool<br>  })</pre> | <pre>{<br>  "enable_integrity_monitoring": true,<br>  "enable_secure_boot": true,<br>  "enable_vtpm": true<br>}</pre> | no |
 | source\_image | Source disk image. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `""` | no |
 | source\_image\_family | Source image family. If neither source\_image nor source\_image\_family is specified, defaults to the latest public CentOS image. | `string` | `"centos-7"` | no |


### PR DESCRIPTION
The previous link resulted in a 404 error.
The updated one redirects to the intended page/id.

- old:  https://terraform.io/providers/hashicorp/google/r/docs/resources/compute_instance_template.html#service_account
- new: https://terraform.io/providers/hashicorp/google/r/docs/resources/compute_instance_template#service_account