### PR TITLE
docs: add fully qualified example link

### DIFF
--- a/modules/mig/README.md
+++ b/modules/mig/README.md
@@ -5,7 +5,7 @@ and optionally, an autoscaler and healthchecks.
 
 ## Usage
 
-See the [simple example](../../examples/mig/simple) for a usage example.
+See the [simple example](https://github.com/terraform-google-modules/terraform-google-vm/tree/master/examples/mig/simple) for a usage example.
 
 ## Upgrading
 


### PR DESCRIPTION
Clicking on the `example` link in https://registry.terraform.io/modules/terraform-google-modules/vm/google/latest/submodules/mig leads to a 404 page. 

I'm proposing a change to make the URL the same as the [`umig` example](https://raw.githubusercontent.com/terraform-google-modules/terraform-google-vm/v7.8.0/modules/umig/README.md).