### PR TITLE
improvement: allow null service_account

### DIFF
--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -92,7 +92,7 @@ resource "google_compute_instance_template" "tpl" {
   }
 
   dynamic "service_account" {
-    for_each = [var.service_account]
+    for_each = var.service_account == null ? [] : [var.service_account]
     content {
       email  = lookup(service_account.value, "email", null)
       scopes = lookup(service_account.value, "scopes", null)


### PR DESCRIPTION
### Description
- The `service_account` variable for the `instant_template` module is a *required* variable
- This variable is used as part of the content section of the dynamic block for the `google_compute_instance_template` resource from the provider
- Thus, it is not possible to create an instant template with no service account associated with it
- As a result it's not possible to go from the `instant_template` module in this repo to a GCE VM which has no service account associated with it

### Why is it an issue
- This is friction full in certain use-cases; for example when installing Anthos bare metal on GCE VMs that have a Service Account associated with it; there are some parts of the install that conflict with this service account
- Thus we want to be able to create instance_templates which has no service account attached