### PR TITLE
Update variables.tf

### DIFF
--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -233,6 +233,7 @@ variable "service_account" {
     email  = string
     scopes = set(string)
   })
+  default     = null
   description = "Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template#service_account."
 }
 


### PR DESCRIPTION
fix : Adding default key to service account

This will remove the need to pass a "null" value if service account isn't required. 
This will in-turn make the requirement of service account - optional.