### PR TITLE
feat: support setting nic_type of primary network interface

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -36,6 +36,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | name\_prefix | Name prefix for the instance template | `string` | `"default-instance-template"` | no |
 | network | The name or self\_link of the network to attach this interface to. Use network attribute for Legacy or Auto subnetted networks and subnetwork for custom subnetted networks. | `string` | `""` | no |
 | network\_ip | Private IP address to assign to the instance if desired. | `string` | `""` | no |
+| nic\_type | Valid values are "VIRTIO\_NET", "GVNIC" or set to null to accept API default behavior. | `string` | `null` | no |
 | on\_host\_maintenance | Instance availability Policy | `string` | `"MIGRATE"` | no |
 | preemptible | Allow the instance to be preempted | `bool` | `false` | no |
 | project\_id | The GCP project ID | `string` | `null` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -111,6 +111,7 @@ resource "google_compute_instance_template" "tpl" {
     subnetwork         = var.subnetwork
     subnetwork_project = var.subnetwork_project
     network_ip         = length(var.network_ip) > 0 ? var.network_ip : null
+    nic_type           = var.nic_type
     stack_type         = var.stack_type
     dynamic "access_config" {
       for_each = var.access_config

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -190,6 +190,17 @@ variable "network_ip" {
   default     = ""
 }
 
+variable "nic_type" {
+  description = "Valid values are \"VIRTIO_NET\", \"GVNIC\" or set to null to accept API default behavior."
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.nic_type == null || var.nic_type == "GVNIC" || var.nic_type == "VIRTIO_NET"
+    error_message = "The \"nic_type\" variable must be set to \"VIRTIO_NET\", \"GVNIC\", or null to allow API default selection."
+  }
+}
+
 variable "stack_type" {
   description = "The stack type for this network interface to identify whether the IPv6 feature is enabled or not. Values are `IPV4_IPV6` or `IPV4_ONLY`. Default behavior is equivalent to IPV4_ONLY."
   type        = string

--- a/modules/umig/README.md
+++ b/modules/umig/README.md
@@ -29,7 +29,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | static\_ips | List of static IPs for VM instances | `list(string)` | `[]` | no |
 | subnetwork | Subnet to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | subnetwork\_project | The project that subnetwork belongs to | `string` | `""` | no |
-| zones | Override the availability zones list to create the resources in. | `list(string)` | `[]` | no |
+| zones | (Optional) List of availability zones to create VM instances in | `list(string)` | `[]` | no |
 
 ## Outputs
 


### PR DESCRIPTION
This PR adds support to specify the NIC type of the primary network interface for instance templates. This field is important VM families and operating systems that support GVNIC and get increased network performance. It defaults to null, the current behavior (unspecified), so this is not a change that requires user action. `var.additional_networks` supports this field, but the primary interface does not.

I can eventually see a breaking change where `var.additional_networks` becomes `var.networks` (or var.network_interfaces) and the primary network interface is inferred from the 1st element in the list. This would eliminate functionality gaps between the primary interface and secondary interfaces.