### PR TITLE
fix: remove unnecessary validation block

### DIFF
--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -232,12 +232,6 @@ variable "additional_networks" {
   }))
   validation {
     condition = alltrue([
-      for ni in var.additional_networks : (ni.network == null) != (ni.subnetwork == null)
-    ])
-    error_message = "All additional network interfaces must define exactly one of \"network\" or \"subnetwork\"."
-  }
-  validation {
-    condition = alltrue([
       for ni in var.additional_networks : ni.nic_type == "GVNIC" || ni.nic_type == "VIRTIO_NET" || ni.nic_type == null
     ])
     error_message = "In the variable additional_networks, field \"nic_type\" must be either \"GVNIC\", \"VIRTIO_NET\" or null."


### PR DESCRIPTION
Although supplying incompatible network and subnetworks will not work, it is not strictly required to supply just one or the other; we should not introduce this change in behavior in 10.0 on a field that existed in 9.0.

This validation block makes more sense in the [HPC Toolkit])(github.com/GoogleCloudPlatform), where I copied it from, but I don't think it belongs in the more general CFT modules.

Follow-up to #330.