### PR TITLE
feat: add support for source_image

### DIFF
--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -186,6 +186,7 @@ variable "additional_disks" {
     disk_size_gb    = number
     disk_type       = string
     disk_labels     = map(string)
+    source_image    = optional(string)
     source_snapshot = optional(string)
   }))
   default = []


### PR DESCRIPTION
In response to my issue:
https://github.com/terraform-google-modules/terraform-google-vm/issues/391

Adding an optional parameter to allow usage of that parameter