### PR TITLE
feat: add disk resource policies

### DIFF
--- a/modules/instance_template/README.md
+++ b/modules/instance_template/README.md
@@ -22,6 +22,7 @@ See the [simple](../../examples/instance_template/simple) for a usage example.
 | can\_ip\_forward | Enable IP forwarding, for NAT instances for example | `string` | `"false"` | no |
 | disk\_encryption\_key | The id of the encryption key that is stored in Google Cloud KMS to use to encrypt all the disks on this instance | `string` | `null` | no |
 | disk\_labels | Labels to be assigned to boot disk, provided as a map | `map(string)` | `{}` | no |
+| disk\_resource\_policies | A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations | `list(string)` | `[]` | no |
 | disk\_size\_gb | Boot disk size in GB | `string` | `"100"` | no |
 | disk\_type | Boot disk type, can be either pd-ssd, local-ssd, or pd-standard | `string` | `"pd-standard"` | no |
 | enable\_confidential\_vm | Whether to enable the Confidential VM configuration on the instance. Note that the instance image must support Confidential VMs. See https://cloud.google.com/compute/docs/images | `bool` | `false` | no |

--- a/modules/instance_template/main.tf
+++ b/modules/instance_template/main.tf
@@ -25,12 +25,13 @@ locals {
 
   boot_disk = [
     {
-      source_image = var.source_image != "" ? format("${local.source_image_project}/${local.source_image}") : format("${local.source_image_project}/${local.source_image_family}")
-      disk_size_gb = var.disk_size_gb
-      disk_type    = var.disk_type
-      disk_labels  = var.disk_labels
-      auto_delete  = var.auto_delete
-      boot         = "true"
+      source_image      = var.source_image != "" ? format("${local.source_image_project}/${local.source_image}") : format("${local.source_image_project}/${local.source_image_family}")
+      disk_size_gb      = var.disk_size_gb
+      disk_type         = var.disk_type
+      disk_labels       = var.disk_labels
+      auto_delete       = var.auto_delete
+      boot              = "true"
+      resource_policies = var.disk_resource_policies
     },
   ]
 
@@ -78,19 +79,20 @@ resource "google_compute_instance_template" "tpl" {
   dynamic "disk" {
     for_each = local.all_disks
     content {
-      auto_delete     = lookup(disk.value, "auto_delete", null)
-      boot            = lookup(disk.value, "boot", null)
-      device_name     = lookup(disk.value, "device_name", null)
-      disk_name       = lookup(disk.value, "disk_name", null)
-      disk_size_gb    = lookup(disk.value, "disk_size_gb", lookup(disk.value, "disk_type", null) == "local-ssd" ? "375" : null)
-      disk_type       = lookup(disk.value, "disk_type", null)
-      interface       = lookup(disk.value, "interface", lookup(disk.value, "disk_type", null) == "local-ssd" ? "NVME" : null)
-      mode            = lookup(disk.value, "mode", null)
-      source          = lookup(disk.value, "source", null)
-      source_image    = lookup(disk.value, "source_image", null)
-      source_snapshot = lookup(disk.value, "source_snapshot", null)
-      type            = lookup(disk.value, "disk_type", null) == "local-ssd" ? "SCRATCH" : "PERSISTENT"
-      labels          = lookup(disk.value, "disk_labels", null)
+      auto_delete       = lookup(disk.value, "auto_delete", null)
+      boot              = lookup(disk.value, "boot", null)
+      device_name       = lookup(disk.value, "device_name", null)
+      disk_name         = lookup(disk.value, "disk_name", null)
+      disk_size_gb      = lookup(disk.value, "disk_size_gb", lookup(disk.value, "disk_type", null) == "local-ssd" ? "375" : null)
+      disk_type         = lookup(disk.value, "disk_type", null)
+      interface         = lookup(disk.value, "interface", lookup(disk.value, "disk_type", null) == "local-ssd" ? "NVME" : null)
+      mode              = lookup(disk.value, "mode", null)
+      source            = lookup(disk.value, "source", null)
+      source_image      = lookup(disk.value, "source_image", null)
+      source_snapshot   = lookup(disk.value, "source_snapshot", null)
+      type              = lookup(disk.value, "disk_type", null) == "local-ssd" ? "SCRATCH" : "PERSISTENT"
+      labels            = lookup(disk.value, "disk_labels", null)
+      resource_policies = lookup(disk.value, "resource_policies", [])
 
       dynamic "disk_encryption_key" {
         for_each = compact([var.disk_encryption_key == null ? null : 1])

--- a/modules/instance_template/metadata.yaml
+++ b/modules/instance_template/metadata.yaml
@@ -153,6 +153,10 @@ spec:
         description: Labels to be assigned to boot disk, provided as a map
         varType: map(string)
         defaultValue: {}
+      - name: disk_resource_policies
+        description: A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations
+        varType: list(string)
+        defaultValue: []
       - name: disk_size_gb
         description: Boot disk size in GB
         varType: string

--- a/modules/instance_template/variables.tf
+++ b/modules/instance_template/variables.tf
@@ -195,6 +195,12 @@ variable "additional_disks" {
   default = []
 }
 
+variable "disk_resource_policies" {
+  description = "A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations"
+  type        = list(string)
+  default     = []
+}
+
 ####################
 # network_interface
 ####################


### PR DESCRIPTION
Adds `resource_policies` to disk to enable the use of automatic snapshot creations.

```
resource_policies: A list (short name or id) of resource policies to attach to this disk for automatic snapshot creations.
Currently a max of 1 resource policy is supported.
```

https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_instance_template