### PR TITLE
feat: Add metadata as an input for compute_instance.

### DIFF
--- a/modules/compute_instance/README.md
+++ b/modules/compute_instance/README.md
@@ -24,6 +24,7 @@ See the [simple](https://github.com/terraform-google-modules/terraform-google-vm
 | instance\_template | Instance template self\_link used to create compute instances | `string` | n/a | yes |
 | ipv6\_access\_config | IPv6 access configurations. Currently a max of 1 IPv6 access configuration is supported. If not specified, the instance will have no external IPv6 Internet access. | <pre>list(object({<br>    network_tier = string<br>  }))</pre> | `[]` | no |
 | labels | (Optional) Labels to override those from the template, provided as a map | `map(string)` | `null` | no |
+| metadata | Metadata, provided as a map. |  `map(string)` | `null` | no |
 | network | Network to deploy to. Only one of network or subnetwork should be specified. | `string` | `""` | no |
 | num\_instances | Number of instances to create. This value is ignored if static\_ips is provided. | `number` | `"1"` | no |
 | region | Region where the instances should be created. | `string` | `null` | no |

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -51,6 +51,7 @@ resource "google_compute_instance_from_template" "compute_instance" {
   deletion_protection = var.deletion_protection
   resource_policies   = var.resource_policies
   labels              = var.labels
+  metadata            = var.metadata
 
   params {
     resource_manager_tags = var.resource_manager_tags

--- a/modules/compute_instance/main.tf
+++ b/modules/compute_instance/main.tf
@@ -51,7 +51,6 @@ resource "google_compute_instance_from_template" "compute_instance" {
   deletion_protection = var.deletion_protection
   resource_policies   = var.resource_policies
   labels              = var.labels
-  metadata            = var.metadata
 
   params {
     resource_manager_tags = var.resource_manager_tags
@@ -91,5 +90,6 @@ resource "google_compute_instance_from_template" "compute_instance" {
   }
 
   source_instance_template = var.instance_template
+  metadata            = var.metadata
 }
 

--- a/modules/compute_instance/variables.tf
+++ b/modules/compute_instance/variables.tf
@@ -128,3 +128,9 @@ variable "resource_manager_tags" {
   type        = map(string)
   default     = null
 }
+
+variable "metadata" {
+  description = "Metadata Key Map"
+  type = map(string)
+  default = null
+}


### PR DESCRIPTION
Exposed `metadata` as a variable for the compute_instance module, and added the metadata attribute to the `compute_instance_from_template` resource in `main.tf`.