### PR TITLE
Bug: Fix Compute Disk Snapshot Schedule

### DIFF
--- a/modules/compute_disk_snapshot/variables.tf
+++ b/modules/compute_disk_snapshot/variables.tf
@@ -40,22 +40,22 @@ variable "snapshot_retention_policy" {
 }
 
 variable "snapshot_schedule" {
-  description = "The scheduled to be used by the snapshot policy. For more details see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#schedule"
+  description = "The schedule to be used by the snapshot policy. For more details see https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#schedule"
   type = object(
     {
-      daily_schedule = object(
+      daily_schedule = optional(object(
         {
           days_in_cycle = number
           start_time    = string
         }
-      )
-      hourly_schedule = object(
+      ))
+      hourly_schedule = optional(object(
         {
           hours_in_cycle = number
           start_time     = string
         }
-      )
-      weekly_schedule = object(
+      ))
+      weekly_schedule = optional(object(
         {
           day_of_weeks = set(object(
             {
@@ -64,9 +64,17 @@ variable "snapshot_schedule" {
             }
           ))
         }
-      )
+      ))
     }
   )
+  validation {
+  condition = (
+    (var.snapshot_schedule.daily_schedule != null && var.snapshot_schedule.hourly_schedule == null && var.snapshot_schedule.weekly_schedule == null) ||
+    (var.snapshot_schedule.daily_schedule == null && var.snapshot_schedule.hourly_schedule != null && var.snapshot_schedule.weekly_schedule == null) ||
+    (var.snapshot_schedule.daily_schedule == null && var.snapshot_schedule.hourly_schedule == null && var.snapshot_schedule.weekly_schedule != null)
+  )
+  error_message = "Exactly one of daily_schedule, hourly_schedule, or weekly_schedule must be provided."
+  }
 }
 
 variable "snapshot_properties" {


### PR DESCRIPTION
This PR updates the compute disk snapshot schedule module as right now it is requiring all 3 schedule types to be added (see below). 

```hcl
│ Error: Invalid value for input variable
│ 
│   on gcp-snapshots.tf line 26, in module "lnd_lab_disk_snapshots":
│   26:   snapshot_schedule = {
│   27:     daily_schedule = {
│   28:       days_in_cycle = 1
│   29:       start_time    = "04:00"
│   30:     }
│   31:   }
│ 
│ The given value is not suitable for module.lndus_disk_snapshots.var.snapshot_schedule declared at .terraform/modules/lndus_disk_snapshots/modules/compute_disk_snapshot/variables.tf:42,1-29:
│ attributes "hourly_schedule" and "weekly_schedule" are required.
```

The error I'm encountering indicates that only one of `daily_schedule`, `weekly_schedule`, or `hourly_schedule`  can be specified in a single google_compute_resource_policy resource's schedule block. 

More info: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/compute_resource_policy#nested_snapshot_schedule_policy

```hcl
snapshot_schedule = {
    daily_schedule = {
      days_in_cycle = 1
      start_time    = "04:00"
    }
    hourly_schedule = {
      hours_in_cycle = 20
      start_time     = "23:00"
    }
    weekly_schedule = {
      day_of_weeks = [
        {
          day        = "MONDAY"
          start_time = "23:00"
        }
      ]
    }
  }
  ```

```
│ "snapshot_schedule_policy.0.schedule.0.weekly_schedule": only one of
│ `snapshot_schedule_policy.0.schedule.0.daily_schedule,snapshot_schedule_policy.0.schedule.0.hourly_schedule,snapshot_schedule_policy.0.schedule.0.weekly_schedule` can be specified, but
│ `snapshot_schedule_policy.0.schedule.0.daily_schedule,snapshot_schedule_policy.0.schedule.0.hourly_schedule,snapshot_schedule_policy.0.schedule.0.weekly_schedule` were specified.
```

Updated the snapshot variable to ensure that exactly one of daily_schedule, hourly_schedule, or weekly_schedule is provided. It uses a validation rule to enforce that only one of these schedules is specified at a time, preventing any combination of multiple schedules. If none or more than one schedule type is provided, it triggers an error.

```hcl
Error: Invalid value for variable
│ 
│   on gcp-snapshots.tf line 26, in module "lndus_disk_snapshots":
│   26:   snapshot_schedule = {
│   27:     daily_schedule = {
│   28:       days_in_cycle = 1
│   29:       start_time    = "04:00"
│   30:     }
│   31:     hourly_schedule = {
│   32:       hours_in_cycle = 20
│   33:       start_time     = "23:00"
│   34:     }
│   35:     weekly_schedule = {
│   36:       day_of_weeks = [
│   37:         {
│   38:           day        = "MONDAY"
│   39:           start_time = "23:00"
│   40:         }
│   41:       ]
│   42:     }
│   43:   }
│     ├────────────────
│     │ var.snapshot_schedule.daily_schedule is object with 2 attributes
│     │ var.snapshot_schedule.hourly_schedule is object with 2 attributes
│     │ var.snapshot_schedule.weekly_schedule is object with 1 attribute "day_of_weeks"
│ 
│ Exactly one of daily_schedule, hourly_schedule, or weekly_schedule must be provided.
│ 
│ This was checked by the validation rule at .terraform/modules/lndus_disk_snapshots/modules/compute_disk_snapshot/variables.tf:70,3-13.
```