### PR TITLE
chore: add pubsub connection metadata

### DIFF
--- a/modules/instance_template/metadata.yaml
+++ b/modules/instance_template/metadata.yaml
@@ -287,6 +287,11 @@ spec:
               version: ">= 4.4"
             spec:
               outputExpr: "{\"SERVICE_ACCOUNT_EMAIL\" : email, \"SERVICE_ACCOUNT_IAM_EMAIL\" : iam_email}"
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-pubsub
+              version: ">= 7.0.0"
+            spec:
+              outputExpr: "{\"TOPIC_ID\": id}"
       - name: service_account
         description: Service account to attach to the instance. See https://www.terraform.io/docs/providers/google/r/compute_instance_template#service_account.
         varType: |-
@@ -330,6 +335,11 @@ spec:
               version: ">= 17.1.0"
             spec:
               outputExpr: "[\"roles/aiplatform.user\"]"
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-pubsub
+              version: ">= 7.0.0"
+            spec:
+              outputExpr: "[\"roles/pubsub.publisher\", \"roles/pubsub.subscriber\"]"
       - name: enable_shielded_vm
         description: Whether to enable the Shielded VM configuration on the instance. Note that the instance image must support Shielded VMs. See https://cloud.google.com/compute/docs/images
         varType: bool


### PR DESCRIPTION
When connection to pubsub is created:
* Add `TOPIC_ID` metadata variable
* Grant `roles/pubsub.publisher`, `roles/pubsub.subscriber` roles for specified project