### PR TITLE
feat: per module requirements configs to vm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ docker_generate_docs:
 		-e ENABLE_BPMETADATA \
 		-v "$(CURDIR)":/workspace \
 		$(REGISTRY_URL)/${DOCKER_IMAGE_DEVELOPER_TOOLS}:${DOCKER_TAG_VERSION_DEVELOPER_TOOLS} \
-		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display'
+		/bin/bash -c 'source /usr/local/bin/task_helper_functions.sh && generate_docs display --per-module-requirements'
 
 # Generate files from autogen
 .PHONY: docker_generate_modules

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -95,15 +95,17 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
+          - roles/compute.imageUser
           - roles/compute.networkAdmin
-          - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
+          - roles/monitoring.viewer
+          - roles/compute.admin
           - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/iam.serviceAccountUser
+          - roles/compute.securityAdmin
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
+      - logging.googleapis.com
+      - monitoring.googleapis.com
+      - serviceusage.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -95,14 +95,14 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.imageUser
-          - roles/compute.networkAdmin
-          - roles/logging.logWriter
-          - roles/monitoring.viewer
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
           - roles/compute.securityAdmin
+          - roles/compute.imageUser
+          - roles/compute.networkAdmin
+          - roles/logging.logWriter
+          - roles/monitoring.viewer
     services:
       - compute.googleapis.com
       - iam.googleapis.com

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -95,6 +95,7 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/monitoring.viewer
           - roles/compute.admin
           - roles/iam.serviceAccountAdmin
           - roles/iam.serviceAccountUser
@@ -102,7 +103,6 @@ spec:
           - roles/compute.imageUser
           - roles/compute.networkAdmin
           - roles/logging.logWriter
-          - roles/monitoring.viewer
     services:
       - compute.googleapis.com
       - iam.googleapis.com

--- a/modules/compute_disk_snapshot/metadata.yaml
+++ b/modules/compute_disk_snapshot/metadata.yaml
@@ -161,18 +161,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/compute.storageAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
-      - iam.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 3.71, < 7"

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -172,13 +172,14 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/compute.networkAdmin
+          - roles/iam.serviceAccountUser
           - roles/iam.serviceAccountAdmin
           - roles/compute.instanceAdmin
           - roles/resourcemanager.projectIamAdmin
           - roles/compute.admin
-          - roles/compute.networkAdmin
-          - roles/iam.serviceAccountUser
     services:
+      - cloudresourcemanager.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -172,16 +172,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -172,9 +172,12 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.instanceAdmin.v1
+          - roles/iam.serviceAccountAdmin
+          - roles/compute.instanceAdmin
+          - roles/resourcemanager.projectIamAdmin
+          - roles/compute.admin
+          - roles/compute.networkAdmin
           - roles/iam.serviceAccountUser
-          - roles/logging.logWriter
     services:
       - compute.googleapis.com
       - iam.googleapis.com

--- a/modules/instance_template/metadata.yaml
+++ b/modules/instance_template/metadata.yaml
@@ -483,8 +483,10 @@ spec:
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
     services:
+      - cloudresourcemanager.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
     providerVersions:
       - source: hashicorp/google-beta
         version: ">= 5.36, < 7"

--- a/modules/instance_template/metadata.yaml
+++ b/modules/instance_template/metadata.yaml
@@ -479,16 +479,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/modules/instance_template/metadata.yaml
+++ b/modules/instance_template/metadata.yaml
@@ -479,9 +479,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
+          - roles/compute.admin
+          - roles/iam.serviceAccountAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - compute.googleapis.com

--- a/modules/mig/metadata.yaml
+++ b/modules/mig/metadata.yaml
@@ -316,16 +316,11 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/logging.logWriter
+          - roles/compute.instanceAdmin.v1
+          - roles/compute.viewer
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/modules/mig/metadata.yaml
+++ b/modules/mig/metadata.yaml
@@ -316,9 +316,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/compute.admin
           - roles/iam.serviceAccountUser
           - roles/logging.logWriter
-          - roles/compute.admin
     services:
       - cloudresourcemanager.googleapis.com
       - compute.googleapis.com

--- a/modules/mig/metadata.yaml
+++ b/modules/mig/metadata.yaml
@@ -316,13 +316,15 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
-          - roles/compute.instanceAdmin.v1
-          - roles/compute.viewer
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
+          - roles/compute.admin
     services:
+      - cloudresourcemanager.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
+      - serviceusage.googleapis.com
+      - storage-api.googleapis.com
     providerVersions:
       - source: hashicorp/google
         version: ">= 4.48, < 7"

--- a/modules/mig_with_percent/metadata.yaml
+++ b/modules/mig_with_percent/metadata.yaml
@@ -303,16 +303,11 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/compute.instanceAdmin.v1
+          - roles/compute.viewer
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/modules/preemptible_and_regular_instance_templates/metadata.yaml
+++ b/modules/preemptible_and_regular_instance_templates/metadata.yaml
@@ -203,9 +203,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/logging.logWriter
           - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
+          - roles/logging.logWriter
     services:
       - compute.googleapis.com
       - iam.googleapis.com

--- a/modules/preemptible_and_regular_instance_templates/metadata.yaml
+++ b/modules/preemptible_and_regular_instance_templates/metadata.yaml
@@ -203,9 +203,9 @@ spec:
     roles:
       - level: Project
         roles:
+          - roles/logging.logWriter
           - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
-          - roles/logging.logWriter
     services:
       - compute.googleapis.com
       - iam.googleapis.com

--- a/modules/preemptible_and_regular_instance_templates/metadata.yaml
+++ b/modules/preemptible_and_regular_instance_templates/metadata.yaml
@@ -203,15 +203,9 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com

--- a/modules/umig/metadata.yaml
+++ b/modules/umig/metadata.yaml
@@ -180,16 +180,10 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/compute.admin
-          - roles/compute.networkAdmin
+          - roles/compute.instanceAdmin.v1
           - roles/iam.serviceAccountUser
-          - roles/iam.serviceAccountAdmin
-          - roles/compute.instanceAdmin
-          - roles/resourcemanager.projectIamAdmin
+          - roles/logging.logWriter
     services:
-      - cloudresourcemanager.googleapis.com
-      - storage-api.googleapis.com
-      - serviceusage.googleapis.com
       - compute.googleapis.com
       - iam.googleapis.com
     providerVersions:

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -31,7 +31,8 @@ locals {
     ]
 
     instance_template = [
-      "roles/compute.instanceAdmin.v1",
+      "roles/compute.admin",
+      "roles/iam.serviceAccountAdmin",
       "roles/iam.serviceAccountUser",
       "roles/logging.logWriter",
     ]

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -15,14 +15,70 @@
  */
 
 locals {
-  vm_required_roles = [
+  per_module_roles = {
+    compute_disk_snapshot = [
+      "roles/compute.storageAdmin",
+      "roles/logging.logWriter",
+    ]
+
+    compute_instance = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    instance_template = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    mig = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/compute.viewer",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    mig_with_percent = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/compute.viewer",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    umig = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    preemptible_and_regular_instance_templates = [
+      "roles/compute.instanceAdmin.v1",
+      "roles/iam.serviceAccountUser",
+      "roles/logging.logWriter",
+    ]
+
+    root = [
+      "roles/compute.admin",
+      "roles/iam.serviceAccountAdmin",
+      "roles/iam.serviceAccountUser",
+      "roles/compute.securityAdmin",
+      "roles/compute.imageUser",
+      "roles/compute.networkAdmin",
+      "roles/logging.logWriter",
+      "roles/monitoring.viewer",
+    ]
+  }
+
+  vm_required_roles = concat([
     "roles/compute.admin",
     "roles/compute.networkAdmin",
     "roles/iam.serviceAccountUser",
     "roles/iam.serviceAccountAdmin",
     "roles/compute.instanceAdmin",
     "roles/resourcemanager.projectIamAdmin",
-  ]
+  ], flatten(values(local.per_module_roles)))
 }
 
 resource "google_service_account" "ci_vm_account" {

--- a/test/setup/iam.tf
+++ b/test/setup/iam.tf
@@ -22,9 +22,12 @@ locals {
     ]
 
     compute_instance = [
-      "roles/compute.instanceAdmin.v1",
+      "roles/compute.admin",
+      "roles/compute.networkAdmin",
       "roles/iam.serviceAccountUser",
-      "roles/logging.logWriter",
+      "roles/iam.serviceAccountAdmin",
+      "roles/compute.instanceAdmin",
+      "roles/resourcemanager.projectIamAdmin",
     ]
 
     instance_template = [
@@ -34,8 +37,7 @@ locals {
     ]
 
     mig = [
-      "roles/compute.instanceAdmin.v1",
-      "roles/compute.viewer",
+      "roles/compute.admin",
       "roles/iam.serviceAccountUser",
       "roles/logging.logWriter",
     ]

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -21,6 +21,7 @@ locals {
     ]
 
     compute_instance = [
+      "cloudresourcemanager.googleapis.com",
       "compute.googleapis.com",
       "iam.googleapis.com",
     ]

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -14,6 +14,52 @@
  * limitations under the License.
  */
 
+locals {
+  per_module_services = {
+    compute_disk_snapshot = [
+      "compute.googleapis.com",
+    ]
+
+    compute_instance = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    instance_template = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    mig = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    mig_with_percent = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    umig = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    preemptible_and_regular_instance_templates = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+    ]
+
+    root = [
+      "compute.googleapis.com",
+      "iam.googleapis.com",
+      "logging.googleapis.com",
+      "monitoring.googleapis.com",
+      "serviceusage.googleapis.com",
+    ]
+  }
+}
+
 module "project_ci_vm" {
   source  = "terraform-google-modules/project-factory/google"
   version = "~> 17.0"
@@ -24,11 +70,8 @@ module "project_ci_vm" {
   folder_id         = var.folder_id
   billing_account   = var.billing_account
 
-  activate_apis = [
+  activate_apis = concat([
     "cloudresourcemanager.googleapis.com",
     "storage-api.googleapis.com",
-    "serviceusage.googleapis.com",
-    "compute.googleapis.com",
-    "iam.googleapis.com",
-  ]
+  ], flatten(values(local.per_module_services)))
 }

--- a/test/setup/main.tf
+++ b/test/setup/main.tf
@@ -28,9 +28,14 @@ locals {
     instance_template = [
       "compute.googleapis.com",
       "iam.googleapis.com",
+      "cloudresourcemanager.googleapis.com",
+      "serviceusage.googleapis.com",
     ]
 
     mig = [
+      "cloudresourcemanager.googleapis.com",
+      "storage-api.googleapis.com",
+      "serviceusage.googleapis.com",
       "compute.googleapis.com",
       "iam.googleapis.com",
     ]


### PR DESCRIPTION
Introduced:

- per_module_roles: to config required roles to run each sub modules.
- per_module_service: to config required services to run each sub modules.

Added feature flag `--per-module-requirements` to generate_docs cmd, to align with the per module configs.