### PR TITLE
feat: Add missing VPC connection for Compute Instance

### DIFF
--- a/examples/compute_instance/disk_snapshot/main.tf
+++ b/examples/compute_instance/disk_snapshot/main.tf
@@ -59,7 +59,7 @@ module "instance_template" {
 
 module "compute_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
-  version = "~> 13.0"
+  version = "~> 14.0"
 
   project_id        = var.project_id
   region            = var.region

--- a/examples/compute_instance/simple/main.tf
+++ b/examples/compute_instance/simple/main.tf
@@ -27,7 +27,7 @@ module "instance_template" {
 
 module "compute_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
-  version = "~> 13.0"
+  version = "~> 14.0"
 
   project_id          = var.project_id
   region              = var.region

--- a/examples/confidential_computing/main.tf
+++ b/examples/confidential_computing/main.tf
@@ -89,7 +89,7 @@ module "instance_template" {
 
 module "compute_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
-  version = "~> 13.0"
+  version = "~> 14.0"
 
   project_id          = var.project_id
   region              = var.region

--- a/examples/confidential_computing_intel/main.tf
+++ b/examples/confidential_computing_intel/main.tf
@@ -89,7 +89,7 @@ module "instance_template" {
 
 module "compute_instance" {
   source  = "terraform-google-modules/vm/google//modules/compute_instance"
-  version = "~> 13.0"
+  version = "~> 14.0"
 
   project_id          = var.project_id
   region              = var.region

--- a/examples/confidential_computing_intel/main.tf
+++ b/examples/confidential_computing_intel/main.tf
@@ -66,6 +66,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
 
 module "instance_template" {
   source = "terraform-google-modules/vm/google//modules/instance_template"
+  version = "~> 13.0"
 
   region     = var.region
   project_id = var.project_id

--- a/examples/confidential_computing_intel/main.tf
+++ b/examples/confidential_computing_intel/main.tf
@@ -65,7 +65,7 @@ resource "google_kms_crypto_key_iam_binding" "crypto_key" {
 }
 
 module "instance_template" {
-  source = "terraform-google-modules/vm/google//modules/instance_template"
+  source  = "terraform-google-modules/vm/google//modules/instance_template"
   version = "~> 13.0"
 
   region     = var.region

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -102,7 +102,7 @@ spec:
         defaultValue: ""
         connections:
           - source:
-              source: github.com/terraform-google-modules/terraform-google-network//modules/subnets
+              source: github.com/terraform-google-modules/terraform-google-network
               version: ~> 18.0.0
             spec:
               outputExpr: subnets_self_links[0]

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -90,6 +90,12 @@ spec:
         description: Network to deploy to. Only one of network or subnetwork should be specified.
         varType: string
         defaultValue: ""
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+              version: "~> 6.0"
+            spec:
+              outputExpr: network_self_link
       - name: subnetwork
         description: Subnet to deploy to. Only one of network or subnetwork should be specified.
         varType: string

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -93,9 +93,9 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: "~> 6.0"
+              version: "~> 18.0.0"
             spec:
-              outputExpr: network_self_link
+              outputExpr: network_name
       - name: subnetwork
         description: Subnet to deploy to. Only one of network or subnetwork should be specified.
         varType: string
@@ -103,13 +103,19 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network//modules/subnets
-              version: ~> 6.0
+              version: ~> 18.0.0
             spec:
-              outputExpr: subnets[0].self_link
+              outputExpr: subnets_self_links[0]
       - name: subnetwork_project
         description: The project that subnetwork belongs to
         varType: string
         defaultValue: ""
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-network
+              version: "~> 18.0.0"
+            spec:
+              outputExpr: project_id
       - name: hostname
         description: Hostname of instances
         varType: string

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -93,7 +93,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: "~> 18.0.0"
+              version: ~> 18.0.0
             spec:
               outputExpr: network_name
       - name: subnetwork
@@ -103,7 +103,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: "~> 18.0.0"
+              version: ~> 18.0.0
             spec:
               outputExpr: subnets_self_links[0]
       - name: subnetwork_project
@@ -113,7 +113,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: "~> 18.0.0"
+              version: ~> 18.0.0
             spec:
               outputExpr: project_id
       - name: hostname

--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -103,7 +103,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ~> 18.0.0
+              version: "~> 18.0.0"
             spec:
               outputExpr: subnets_self_links[0]
       - name: subnetwork_project

--- a/modules/mig/metadata.display.yaml
+++ b/modules/mig/metadata.display.yaml
@@ -37,11 +37,6 @@ spec:
           name: autoscaling_cpu
           title: Autoscaling Cpu
           properties:
-            target:
-              name: target
-              title: Target
-              min: 0.0
-              max: 1.0
             predictive_method:
               name: predictive_method
               title: Predictive Method
@@ -50,6 +45,10 @@ spec:
                   value: NONE
                 - label: OPTIMIZE_AVAILABILITY
                   value: OPTIMIZE_AVAILABILITY
+            target:
+              name: target
+              title: Target
+              max: 1
         autoscaling_enabled:
           name: autoscaling_enabled
           title: Autoscaling Enabled
@@ -60,8 +59,7 @@ spec:
             target:
               name: target
               title: Target
-              min: 0.0
-              max: 1.0
+              max: 1
         autoscaling_metric:
           name: autoscaling_metric
           title: Autoscaling Metric
@@ -69,8 +67,7 @@ spec:
             target:
               name: target
               title: Target
-              min: 0.0
-              max: 1.0
+              max: 1
             type:
               name: type
               title: Type
@@ -99,16 +96,13 @@ spec:
             fixed_replicas:
               name: fixed_replicas
               title: Fixed Replicas
-              min: 0
             percent_replicas:
               name: percent_replicas
               title: Percent Replicas
-              min: 0
               max: 100
         cooldown_period:
           name: cooldown_period
           title: Cooldown Period
-          min: 0
         distribution_policy_target_shape:
           name: distribution_policy_target_shape
           title: Distribution Policy Target Shape
@@ -128,6 +122,23 @@ spec:
           name: health_check
           title: Health Check
           properties:
+            initial_delay_sec:
+              name: initial_delay_sec
+              title: Initial Delay Sec
+              max: 3600
+            port:
+              name: port
+              title: Port
+              min: 1
+              max: 65535
+            proxy_header:
+              name: proxy_header
+              title: Proxy Header
+              enumValueLabels:
+                - label: NONE
+                  value: NONE
+                - label: PROXY_V1
+                  value: PROXY_V1
             type:
               name: type
               title: Type
@@ -140,24 +151,6 @@ spec:
                   value: TCP
                 - label: SSL
                   value: SSL
-            initial_delay_sec:
-              name: initial_delay_sec
-              title: Initial Delay Sec
-              min: 0
-              max: 3600
-            proxy_header:
-              name: proxy_header
-              title: Proxy Header
-              enumValueLabels:
-                - label: NONE
-                  value: NONE
-                - label: PROXY_V1
-                  value: PROXY_V1
-            port:
-              name: port
-              title: Port
-              min: 1
-              max: 65535
         health_check_name:
           name: health_check_name
           title: Health Check Name
@@ -166,13 +159,13 @@ spec:
         hostname:
           name: hostname
           title: Hostname
-          level: 1
           regexValidation: ^[a-z][a-z0-9-]{0,61}[a-z0-9]$
           validation: Hostname must be between 1 and 63 characters long, start with a lowercase letter, and can contain lowercase letters, numbers, and hyphens.
+          level: 1
         instance_template:
           name: instance_template
           title: Instance Template
-          regexValidation: "^https://www.googleapis.com/compute/v1/projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/(?:global|regions/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)/instanceTemplates/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$"
+          regexValidation: ^https://www.googleapis.com/compute/v1/projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/(?:global|regions/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)/instanceTemplates/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$
           validation: Invalid template url format, valid format is either https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceTemplates/{template_name} (regional) or https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates/{template_name} (global).
         labels:
           name: labels
@@ -226,7 +219,7 @@ spec:
             schedule:
               name: schedule
               title: Schedule
-              regexValidation: "^([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?)(,([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?))* ([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?)(,([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?))* ([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?)(,([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?))* ([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?)(,([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?))* ([*]|([0-6])(-([0-6]))?)(,([*]|([0-6])(-([0-6]))?))*$"
+              regexValidation: ^([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?)(,([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?))* ([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?)(,([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?))* ([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?)(,([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?))* ([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?)(,([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?))* ([*]|([0-6])(-([0-6]))?)(,([*]|([0-6])(-([0-6]))?))*$
               validation: Schedule must be in cron format.
         stateful_disks:
           name: stateful_disks
@@ -258,7 +251,6 @@ spec:
         target_size:
           name: target_size
           title: Target Size
-          min: 0
           level: 1
         update_policy:
           name: update_policy
@@ -275,26 +267,15 @@ spec:
             max_surge_percent:
               name: max_surge_percent
               title: Max Surge Percent
-              min: 0
               max: 100
             max_unavailable_percent:
               name: max_unavailable_percent
               title: Max Unavailable Percent
-              min: 0
               max: 100
             min_ready_sec:
               name: min_ready_sec
               title: Min Ready Sec
-              min: 0
               max: 3600
-            replacement_method:
-              name: replacement_method
-              title: Replacement Method
-              enumValueLabels:
-                - label: RECREATE
-                  value: RECREATE
-                - label: SUBSTITUTE
-                  value: SUBSTITUTE
             minimal_action:
               name: minimal_action
               title: Minimal Action
@@ -307,14 +288,6 @@ spec:
                   value: REFRESH
                 - label: NONE
                   value: NONE
-            type:
-              name: type
-              title: Type
-              enumValueLabels:
-                - label: PROACTIVE
-                  value: PROACTIVE
-                - label: OPPORTUNISTIC
-                  value: OPPORTUNISTIC
             most_disruptive_allowed_action:
               name: most_disruptive_allowed_action
               title: Most Disruptive Allowed Action
@@ -327,6 +300,22 @@ spec:
                   value: REFRESH
                 - label: NONE
                   value: NONE
+            replacement_method:
+              name: replacement_method
+              title: Replacement Method
+              enumValueLabels:
+                - label: RECREATE
+                  value: RECREATE
+                - label: SUBSTITUTE
+                  value: SUBSTITUTE
+            type:
+              name: type
+              title: Type
+              enumValueLabels:
+                - label: PROACTIVE
+                  value: PROACTIVE
+                - label: OPPORTUNISTIC
+                  value: OPPORTUNISTIC
         wait_for_instances:
           name: wait_for_instances
           title: Wait For Instances

--- a/modules/mig/metadata.display.yaml
+++ b/modules/mig/metadata.display.yaml
@@ -37,6 +37,11 @@ spec:
           name: autoscaling_cpu
           title: Autoscaling Cpu
           properties:
+            target:
+              name: target
+              title: Target
+              min: 0.0
+              max: 1.0
             predictive_method:
               name: predictive_method
               title: Predictive Method
@@ -45,10 +50,6 @@ spec:
                   value: NONE
                 - label: OPTIMIZE_AVAILABILITY
                   value: OPTIMIZE_AVAILABILITY
-            target:
-              name: target
-              title: Target
-              max: 1
         autoscaling_enabled:
           name: autoscaling_enabled
           title: Autoscaling Enabled
@@ -59,7 +60,8 @@ spec:
             target:
               name: target
               title: Target
-              max: 1
+              min: 0.0
+              max: 1.0
         autoscaling_metric:
           name: autoscaling_metric
           title: Autoscaling Metric
@@ -67,7 +69,8 @@ spec:
             target:
               name: target
               title: Target
-              max: 1
+              min: 0.0
+              max: 1.0
             type:
               name: type
               title: Type
@@ -96,13 +99,16 @@ spec:
             fixed_replicas:
               name: fixed_replicas
               title: Fixed Replicas
+              min: 0
             percent_replicas:
               name: percent_replicas
               title: Percent Replicas
+              min: 0
               max: 100
         cooldown_period:
           name: cooldown_period
           title: Cooldown Period
+          min: 0
         distribution_policy_target_shape:
           name: distribution_policy_target_shape
           title: Distribution Policy Target Shape
@@ -122,23 +128,6 @@ spec:
           name: health_check
           title: Health Check
           properties:
-            initial_delay_sec:
-              name: initial_delay_sec
-              title: Initial Delay Sec
-              max: 3600
-            port:
-              name: port
-              title: Port
-              min: 1
-              max: 65535
-            proxy_header:
-              name: proxy_header
-              title: Proxy Header
-              enumValueLabels:
-                - label: NONE
-                  value: NONE
-                - label: PROXY_V1
-                  value: PROXY_V1
             type:
               name: type
               title: Type
@@ -151,6 +140,24 @@ spec:
                   value: TCP
                 - label: SSL
                   value: SSL
+            initial_delay_sec:
+              name: initial_delay_sec
+              title: Initial Delay Sec
+              min: 0
+              max: 3600
+            proxy_header:
+              name: proxy_header
+              title: Proxy Header
+              enumValueLabels:
+                - label: NONE
+                  value: NONE
+                - label: PROXY_V1
+                  value: PROXY_V1
+            port:
+              name: port
+              title: Port
+              min: 1
+              max: 65535
         health_check_name:
           name: health_check_name
           title: Health Check Name
@@ -159,13 +166,13 @@ spec:
         hostname:
           name: hostname
           title: Hostname
+          level: 1
           regexValidation: ^[a-z][a-z0-9-]{0,61}[a-z0-9]$
           validation: Hostname must be between 1 and 63 characters long, start with a lowercase letter, and can contain lowercase letters, numbers, and hyphens.
-          level: 1
         instance_template:
           name: instance_template
           title: Instance Template
-          regexValidation: ^https://www.googleapis.com/compute/v1/projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/(?:global|regions/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)/instanceTemplates/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$
+          regexValidation: "^https://www.googleapis.com/compute/v1/projects/[a-z0-9](?:[-a-z0-9]{0,61}[a-z0-9])?/(?:global|regions/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)/instanceTemplates/[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?$"
           validation: Invalid template url format, valid format is either https://www.googleapis.com/compute/v1/projects/{project}/regions/{region}/instanceTemplates/{template_name} (regional) or https://www.googleapis.com/compute/v1/projects/{project}/global/instanceTemplates/{template_name} (global).
         labels:
           name: labels
@@ -219,7 +226,7 @@ spec:
             schedule:
               name: schedule
               title: Schedule
-              regexValidation: ^([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?)(,([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?))* ([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?)(,([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?))* ([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?)(,([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?))* ([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?)(,([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?))* ([*]|([0-6])(-([0-6]))?)(,([*]|([0-6])(-([0-6]))?))*$
+              regexValidation: "^([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?)(,([*]|([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9])(-([0-9]|1[0-9]|2[0-9]|3[0-9]|4[0-9]|5[0-9]))?))* ([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?)(,([*]|([0-9]|1[0-9]|2[0-3])(-([0-9]|1[0-9]|2[0-3]))?))* ([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?)(,([*]|([1-9]|1[0-9]|2[0-9]|3[0-1])(-([1-9]|1[0-9]|2[0-9]|3[0-1]))?))* ([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?)(,([*]|([1-9]|1[0-2])(-([1-9]|1[0-2]))?))* ([*]|([0-6])(-([0-6]))?)(,([*]|([0-6])(-([0-6]))?))*$"
               validation: Schedule must be in cron format.
         stateful_disks:
           name: stateful_disks
@@ -251,6 +258,7 @@ spec:
         target_size:
           name: target_size
           title: Target Size
+          min: 0
           level: 1
         update_policy:
           name: update_policy
@@ -267,15 +275,26 @@ spec:
             max_surge_percent:
               name: max_surge_percent
               title: Max Surge Percent
+              min: 0
               max: 100
             max_unavailable_percent:
               name: max_unavailable_percent
               title: Max Unavailable Percent
+              min: 0
               max: 100
             min_ready_sec:
               name: min_ready_sec
               title: Min Ready Sec
+              min: 0
               max: 3600
+            replacement_method:
+              name: replacement_method
+              title: Replacement Method
+              enumValueLabels:
+                - label: RECREATE
+                  value: RECREATE
+                - label: SUBSTITUTE
+                  value: SUBSTITUTE
             minimal_action:
               name: minimal_action
               title: Minimal Action
@@ -288,6 +307,14 @@ spec:
                   value: REFRESH
                 - label: NONE
                   value: NONE
+            type:
+              name: type
+              title: Type
+              enumValueLabels:
+                - label: PROACTIVE
+                  value: PROACTIVE
+                - label: OPPORTUNISTIC
+                  value: OPPORTUNISTIC
             most_disruptive_allowed_action:
               name: most_disruptive_allowed_action
               title: Most Disruptive Allowed Action
@@ -300,22 +327,6 @@ spec:
                   value: REFRESH
                 - label: NONE
                   value: NONE
-            replacement_method:
-              name: replacement_method
-              title: Replacement Method
-              enumValueLabels:
-                - label: RECREATE
-                  value: RECREATE
-                - label: SUBSTITUTE
-                  value: SUBSTITUTE
-            type:
-              name: type
-              title: Type
-              enumValueLabels:
-                - label: PROACTIVE
-                  value: PROACTIVE
-                - label: OPPORTUNISTIC
-                  value: OPPORTUNISTIC
         wait_for_instances:
           name: wait_for_instances
           title: Wait For Instances


### PR DESCRIPTION
Adding missing VPC connection for Compute Instance.

Testing Steps for VPC Connection:

Prepared and used the Automation script for implementing missing connections in ADC (currently in testing phase) to perform the below steps:

1) Ingest Component Revision (BYOC):
- Set the gcloud configuration to point to the Staging environment.
- Create the template metadata for the Compute Instance component.
- Create a template revision to pull our specific code tag (e.g., v15.0.0) into the private catalog.

2) Adding components and connections and filling up param values (ADC Canvas):
   a) In the ADC canvas, add the custom Compute Instance and VPC components.
   b) Add a connection line between the two. This stage also passed successfully.
   c) Fill all required configuration parameters for all 2 components (e.g., region, project, name, network and subnet details, etc)
   d) [Created an Instance template manually in the same project and region. Added that as a configuration parameter value for Compute Instance]

3) App Deployment:
   a) Create a new application with the connected components.
   b) Deploy and ensure the application deployment completes successfully.
   c) Iterate in case of failures, trying with different values.

Successful testing in Staging environment:
https://screenshot.googleplex.com/ePc8tcspLYjHHmg