### PR TITLE
feat: Update VPC version for Compute Instance

### DIFF
--- a/modules/compute_instance/metadata.yaml
+++ b/modules/compute_instance/metadata.yaml
@@ -93,7 +93,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ~> 18.0.0
+              version: ">= 16.0.1"
             spec:
               outputExpr: network_name
       - name: subnetwork
@@ -103,7 +103,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ~> 18.0.0
+              version: ">= 16.0.1"
             spec:
               outputExpr: subnets_self_links[0]
       - name: subnetwork_project
@@ -113,7 +113,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-network
-              version: ~> 18.0.0
+              version: ">= 16.0.1"
             spec:
               outputExpr: project_id
       - name: hostname


### PR DESCRIPTION
Updated VPC version for Compute Instance module.

Testing Steps for VPC Connection:

Used the Automation script for implementing missing connections in ADC to perform the below steps:

1) Ingest Component Revision (BYOC):
Set the gcloud configuration to point to the Staging environment.
Create the template metadata for the Compute Instance component.
Create a template revision to pull our specific code tag (e.g., v15.1.0) into the private catalog.

2) Adding components and connections and filling up param values (ADC Canvas):
a) In the ADC canvas, add the custom Compute Instance and VPC components.
b) Add a connection line between the two. This stage also passed successfully.
c) Fill all required configuration parameters for all 2 components (e.g., region, project, name, network and subnet details, etc)
d) The script added an Instance template as a dependency component in the same project and region. This is added as a configuration parameter value for Compute Instance.

3) App Deployment:
a) Create a new application with the connected components.
b) Deploy and ensure the application deployment completes successfully.
c) Iterate in case of failures, trying with different values.

Successful testing in Staging environment:
https://screenshot.googleplex.com/4MwPrVcqw9Jj7Lg

Test logs:
https://paste.googleplex.com/5945273907019776