### PR TITLE
fix: bump google-beta minimum version to >= 7.19 for vlan attribute support

### DIFF
--- a/modules/instance_template/versions.tf
+++ b/modules/instance_template/versions.tf
@@ -19,7 +19,7 @@ terraform {
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 5.36, < 8"
+      version = ">= 7.19, < 8"
     }
   }
   provider_meta "google" {


### PR DESCRIPTION
## Description

Fixes #575

The `vlan` attribute on `network_interface` in `google_compute_instance_template` was introduced in `google-beta` provider v7.19.0. The previous version constraint (`>= 5.36, < 8`) allowed users to use older provider versions that don't support this attribute, leading to:

```
Error: Unsupported argument
An argument named "vlan" is not expected here.
```

## Changes

- Updated `modules/instance_template/versions.tf` to require `google-beta >= 7.19, < 8`

## Impact

Users with `google-beta` < 7.19 will need to upgrade their provider version. This is a necessary constraint since the module now uses the `vlan` attribute which was added in v7.19.0.