### PR TITLE
feat(mig): add zonal MIG support via optional zone variable

### DIFF
--- a/modules/mig/main.tf
+++ b/modules/mig/main.tf
@@ -17,21 +17,24 @@
 // This file was automatically generated from a template in ./autogen
 
 locals {
+  is_zonal = var.zone != null
   healthchecks = concat(
     google_compute_health_check.https[*].self_link,
     google_compute_health_check.http[*].self_link,
     google_compute_health_check.tcp[*].self_link,
   )
-  distribution_policy_zones    = coalescelist(var.distribution_policy_zones, data.google_compute_zones.available.names)
+  distribution_policy_zones    = local.is_zonal ? [] : coalescelist(var.distribution_policy_zones, try(data.google_compute_zones.available[0].names, []))
   autoscaling_scale_in_enabled = var.autoscaling_scale_in_control.fixed_replicas != null || var.autoscaling_scale_in_control.percent_replicas != null
 }
 
 data "google_compute_zones" "available" {
+  count   = local.is_zonal ? 0 : 1
   project = var.project_id
   region  = var.region
 }
 
 resource "google_compute_region_instance_group_manager" "mig" {
+  count              = local.is_zonal ? 0 : 1
   provider           = google-beta
   base_instance_name = var.hostname
   project            = var.project_id
@@ -123,12 +126,143 @@ resource "google_compute_region_instance_group_manager" "mig" {
 
 resource "google_compute_region_autoscaler" "autoscaler" {
   provider = google
-  count    = var.autoscaling_enabled ? 1 : 0
+  count    = var.autoscaling_enabled && !local.is_zonal ? 1 : 0
   name     = var.autoscaler_name == "" ? "${var.hostname}-autoscaler" : var.autoscaler_name
   project  = var.project_id
   region   = var.region
 
-  target = google_compute_region_instance_group_manager.mig.self_link
+  target = google_compute_region_instance_group_manager.mig[0].self_link
+
+  autoscaling_policy {
+    max_replicas    = var.max_replicas
+    min_replicas    = var.min_replicas
+    cooldown_period = var.cooldown_period
+    mode            = var.autoscaling_mode
+    dynamic "scale_in_control" {
+      for_each = local.autoscaling_scale_in_enabled ? [var.autoscaling_scale_in_control] : []
+      content {
+        max_scaled_in_replicas {
+          fixed   = lookup(scale_in_control.value, "fixed_replicas", null)
+          percent = lookup(scale_in_control.value, "percent_replicas", null)
+        }
+        time_window_sec = lookup(scale_in_control.value, "time_window_sec", null)
+      }
+    }
+    dynamic "cpu_utilization" {
+      for_each = var.autoscaling_cpu
+      content {
+        target            = lookup(cpu_utilization.value, "target", null)
+        predictive_method = lookup(cpu_utilization.value, "predictive_method", null)
+      }
+    }
+    dynamic "metric" {
+      for_each = var.autoscaling_metric
+      content {
+        name   = lookup(metric.value, "name", null)
+        target = lookup(metric.value, "target", null)
+        type   = lookup(metric.value, "type", null)
+      }
+    }
+    dynamic "load_balancing_utilization" {
+      for_each = var.autoscaling_lb
+      content {
+        target = lookup(load_balancing_utilization.value, "target", null)
+      }
+    }
+    dynamic "scaling_schedules" {
+      for_each = var.scaling_schedules
+      content {
+        disabled              = lookup(scaling_schedules.value, "disabled", null)
+        duration_sec          = lookup(scaling_schedules.value, "duration_sec", null)
+        min_required_replicas = lookup(scaling_schedules.value, "min_required_replicas", null)
+        name                  = lookup(scaling_schedules.value, "name", null)
+        schedule              = lookup(scaling_schedules.value, "schedule", null)
+        time_zone             = lookup(scaling_schedules.value, "time_zone", null)
+      }
+    }
+  }
+}
+
+resource "google_compute_instance_group_manager" "mig_zonal" {
+  count              = local.is_zonal ? 1 : 0
+  provider           = google-beta
+  base_instance_name = var.hostname
+  project            = var.project_id
+
+  version {
+    name              = "${var.hostname}-mig-version-0"
+    instance_template = var.instance_template
+  }
+
+  name = var.mig_name == "" ? "${var.hostname}-mig" : var.mig_name
+  zone = var.zone
+
+  dynamic "named_port" {
+    for_each = var.named_ports
+    content {
+      name = lookup(named_port.value, "name", null)
+      port = lookup(named_port.value, "port", null)
+    }
+  }
+
+  target_pools = var.target_pools
+  target_size  = var.autoscaling_enabled ? null : var.target_size
+
+  wait_for_instances = var.wait_for_instances
+
+  dynamic "auto_healing_policies" {
+    for_each = local.healthchecks
+    content {
+      health_check      = auto_healing_policies.value
+      initial_delay_sec = var.health_check["initial_delay_sec"]
+    }
+  }
+
+  dynamic "stateful_disk" {
+    for_each = var.stateful_disks
+    content {
+      device_name = stateful_disk.value.device_name
+      delete_rule = lookup(stateful_disk.value, "delete_rule", null)
+    }
+  }
+
+  dynamic "update_policy" {
+    for_each = var.update_policy
+    content {
+      max_surge_fixed         = lookup(update_policy.value, "max_surge_fixed", null)
+      max_surge_percent       = lookup(update_policy.value, "max_surge_percent", null)
+      max_unavailable_fixed   = lookup(update_policy.value, "max_unavailable_fixed", null)
+      max_unavailable_percent = lookup(update_policy.value, "max_unavailable_percent", null)
+      min_ready_sec           = lookup(update_policy.value, "min_ready_sec", null)
+      replacement_method      = lookup(update_policy.value, "replacement_method", null)
+      minimal_action          = update_policy.value.minimal_action
+      type                    = update_policy.value.type
+    }
+  }
+
+  all_instances_config {
+    labels = var.labels
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  timeouts {
+    create = var.mig_timeouts.create
+    update = var.mig_timeouts.update
+    delete = var.mig_timeouts.delete
+  }
+}
+
+resource "google_compute_autoscaler" "autoscaler_zonal" {
+  provider = google
+  count    = var.autoscaling_enabled && local.is_zonal ? 1 : 0
+  name     = var.autoscaler_name == "" ? "${var.hostname}-autoscaler" : var.autoscaler_name
+  project  = var.project_id
+  zone     = var.zone
+
+  target = google_compute_instance_group_manager.mig_zonal[0].self_link
 
   autoscaling_policy {
     max_replicas    = var.max_replicas

--- a/modules/mig/outputs.tf
+++ b/modules/mig/outputs.tf
@@ -18,17 +18,17 @@
 
 output "self_link" {
   description = "Self-link of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.self_link
+  value       = var.zone != null ? google_compute_instance_group_manager.mig_zonal[0].self_link : google_compute_region_instance_group_manager.mig[0].self_link
 }
 
 output "instance_group" {
   description = "Instance-group url of managed instance group"
-  value       = google_compute_region_instance_group_manager.mig.instance_group
+  value       = var.zone != null ? google_compute_instance_group_manager.mig_zonal[0].instance_group : google_compute_region_instance_group_manager.mig[0].instance_group
 }
 
 output "instance_group_manager" {
-  description = "An instance of google_compute_region_instance_group_manager of the instance group."
-  value       = google_compute_region_instance_group_manager.mig
+  description = "An instance of the instance group manager resource."
+  value       = var.zone != null ? google_compute_instance_group_manager.mig_zonal[0] : google_compute_region_instance_group_manager.mig[0]
 }
 
 output "health_check_self_links" {
@@ -37,9 +37,13 @@ output "health_check_self_links" {
 }
 
 output "apphub_workload_uri" {
-  value = {
-    workload_uri = "//compute.googleapis.com/projects${element(split("/projects", google_compute_region_instance_group_manager.mig.instance_group), 1)}"
-    workload_id  = substr(join("-", [tostring(google_compute_region_instance_group_manager.mig.name), md5(join("-", [var.region, var.project_id]))]), 0, 63)
+  value = var.zone != null ? {
+    workload_uri = "//compute.googleapis.com/projects${element(split("/projects", google_compute_instance_group_manager.mig_zonal[0].instance_group), 1)}"
+    workload_id  = substr(join("-", [tostring(google_compute_instance_group_manager.mig_zonal[0].name), md5(join("-", [var.zone, var.project_id]))]), 0, 63)
+    location     = var.zone
+    } : {
+    workload_uri = "//compute.googleapis.com/projects${element(split("/projects", google_compute_region_instance_group_manager.mig[0].instance_group), 1)}"
+    workload_id  = substr(join("-", [tostring(google_compute_region_instance_group_manager.mig[0].name), md5(join("-", [var.region, var.project_id]))]), 0, 63)
     location     = var.region
   }
   description = "Workload URI in CAIS style to be used by Apphub."

--- a/modules/mig/variables.tf
+++ b/modules/mig/variables.tf
@@ -22,8 +22,15 @@ variable "project_id" {
 }
 
 variable "region" {
-  description = "The Google Cloud region where the managed instance group resides."
+  description = "The Google Cloud region where the managed instance group resides. Required when zone is not set."
   type        = string
+  default     = null
+}
+
+variable "zone" {
+  description = "The Google Cloud zone where the managed instance group resides. When set, a zonal MIG is created using google_compute_instance_group_manager instead of the regional variant. Exactly one of zone or region must be provided."
+  type        = string
+  default     = null
 }
 
 variable "mig_name" {


### PR DESCRIPTION
## Problem

The `modules/mig` module only supports
`google_compute_region_instance_group_manager`, which requires a
`region` and always creates a **regional** MIG spread across multiple
zones. There is no way to create a **zonal**
`google_compute_instance_group_manager` through this module, even
though both resource types are part of the Compute Engine MIG family
and share most of the same interface.

## Solution

Add an optional `zone` variable (default `null`). When `zone` is set:

- A `google_compute_instance_group_manager` (**zonal**) is created
  instead of the regional variant.
- A `google_compute_autoscaler` is created instead of
  `google_compute_region_autoscaler`.
- The `data "google_compute_zones"` lookup is skipped (it is only
  meaningful for regional distribution policy).

When `zone` is **not** set (i.e. `region` is provided), the module
behaves exactly as before — fully backward-compatible.

## Changes

| file | what changed |
|---|---|
| `variables.tf` | `region` becomes optional (`default = null`); new `zone` variable added (`default = null`) |
| `main.tf` | `is_zonal` local; `data.google_compute_zones` and regional MIG/autoscaler gated on `!is_zonal`; new `google_compute_instance_group_manager.mig_zonal` and `google_compute_autoscaler.autoscaler_zonal` added for the zonal path |
| `outputs.tf` | All outputs coalesced across both resource paths via ternary on `var.zone != null` |

## Backward compatibility

Existing callers that pass `region` are unaffected. The `region`
variable now has `default = null` rather than being required, but any
caller that previously worked will continue to work without any
changes.

## Usage (new zonal path)

```hcl
module "mig" {
  source  = "terraform-google-modules/vm/google//modules/mig"

  project_id        = "my-project"
  zone              = "us-central1-a"
  hostname          = "my-app"
  instance_template = google_compute_instance_template.default.self_link
  target_size       = 3
}
```